### PR TITLE
Make a few changes to allow all code to be loaded as one project

### DIFF
--- a/src/deprecatedCompat/4.2/abstractConstructorTypes.ts
+++ b/src/deprecatedCompat/4.2/abstractConstructorTypes.ts
@@ -59,15 +59,7 @@ namespace ts {
 
     // Patch `createNodeFactory` because it creates the factories that are provided to transformers
     // in the public API.
-
-    const prevCreateNodeFactory = createNodeFactory;
-
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-qualifier
-    ts.createNodeFactory = (flags, baseFactory) => {
-        const factory = prevCreateNodeFactory(flags, baseFactory);
-        patchNodeFactory(factory);
-        return factory;
-    };
+    addNodeFactoryPatcher(patchNodeFactory);
 
     // Patch `ts.factory` because its public
     patchNodeFactory(factory);

--- a/src/deprecatedCompat/4.6/importTypeAssertions.ts
+++ b/src/deprecatedCompat/4.6/importTypeAssertions.ts
@@ -80,15 +80,7 @@ namespace ts {
 
     // Patch `createNodeFactory` because it creates the factories that are provided to transformers
     // in the public API.
-
-    const prevCreateNodeFactory = createNodeFactory;
-
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-qualifier
-    ts.createNodeFactory = (flags, baseFactory) => {
-        const factory = prevCreateNodeFactory(flags, baseFactory);
-        patchNodeFactory(factory);
-        return factory;
-    };
+    addNodeFactoryPatcher(patchNodeFactory);
 
     // Patch `ts.factory` because its public
     patchNodeFactory(factory);

--- a/src/deprecatedCompat/4.7/typeParameterModifiers.ts
+++ b/src/deprecatedCompat/4.7/typeParameterModifiers.ts
@@ -65,15 +65,7 @@ namespace ts {
 
     // Patch `createNodeFactory` because it creates the factories that are provided to transformers
     // in the public API.
-
-    const prevCreateNodeFactory = createNodeFactory;
-
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-qualifier
-    ts.createNodeFactory = (flags, baseFactory) => {
-        const factory = prevCreateNodeFactory(flags, baseFactory);
-        patchNodeFactory(factory);
-        return factory;
-    };
+    addNodeFactoryPatcher(patchNodeFactory);
 
     // Patch `ts.factory` because its public
     patchNodeFactory(factory);

--- a/src/deprecatedCompat/4.8/mergeDecoratorsAndModifiers.ts
+++ b/src/deprecatedCompat/4.8/mergeDecoratorsAndModifiers.ts
@@ -1397,15 +1397,7 @@ namespace ts {
 
     // Patch `createNodeFactory` because it creates the factories that are provided to transformers
     // in the public API.
-
-    const prevCreateNodeFactory = createNodeFactory;
-
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-qualifier
-    ts.createNodeFactory = (flags, baseFactory) => {
-        const factory = prevCreateNodeFactory(flags, baseFactory);
-        patchNodeFactory(factory);
-        return factory;
-    };
+    addNodeFactoryPatcher(patchNodeFactory);
 
     // Patch `ts.factory` because its public
     patchNodeFactory(factory);

--- a/src/tsserver/webServer.ts
+++ b/src/tsserver/webServer.ts
@@ -1,8 +1,12 @@
 /*@internal*/
-
-/// <reference lib="webworker" />
-
 namespace ts.server {
+    declare const addEventListener: any;
+    declare const postMessage: any;
+    declare const close: any;
+    declare const location: any;
+    declare const XMLHttpRequest: any;
+    declare const self: any;
+
     const nullLogger: Logger = {
         close: noop,
         hasLevel: returnFalse,

--- a/src/webServer/webServer.ts
+++ b/src/webServer/webServer.ts
@@ -1,8 +1,9 @@
 /*@internal*/
-/// <reference lib="dom" />
-/// <reference lib="webworker.importscripts" />
 
 namespace ts.server {
+    declare const fetch: any;
+    declare const importScripts: any;
+
     export interface HostWithWriteMessage {
         writeMessage(s: any): void;
     }
@@ -112,8 +113,6 @@ namespace ts.server {
         }
     }
 
-    export declare const dynamicImport: ((id: string) => Promise<any>) | undefined;
-
     // Attempt to load `dynamicImport`
     if (typeof importScripts === "function") {
         try {
@@ -132,9 +131,10 @@ namespace ts.server {
         const getWebPath = (path: string) => startsWith(path, directorySeparator) ? path.replace(directorySeparator, getExecutingDirectoryPath()) : undefined;
 
         const dynamicImport = async (id: string): Promise<any> => {
+            const serverDynamicImport: ((id: string) => Promise<any>) | undefined = (server as any).dynamicImport;
             // Use syntactic dynamic import first, if available
-            if (server.dynamicImport) {
-                return server.dynamicImport(id);
+            if (serverDynamicImport) {
+                return serverDynamicImport(id);
             }
 
             throw new Error("Dynamic import not implemented");


### PR DESCRIPTION
**Please do not comment on this PR**. Depending on how this set of PRs evolves, this PR's contents may change entirely based on the order of commits.

This PR is a part of a stack:

  1. Make a few changes to allow all code to be loaded as one project (this PR)
  1. [Explicitly reference ts namespace in tsserverlibrary](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-2)
  1. [Generated module conversion step - unindent](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-3)
  1. [Generated module conversion step - explicitify](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-4)
  1. [Generated module conversion step - stripNamespaces](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-5)
  1. [Generated module conversion step - inlineImports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-6)
  1. [Generated module conversion step - .git-ignore-blame-revs](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-7)
  1. [Add gitlens settings suggestion](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-8)
  1. [Make processDiagnosticMessages generate a module](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-9)
  1. [Fix up linting, make lint clean](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-10)
  1. [Undo changes needed to load codebase into ts-morph](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-11)
  1. [Add JSDoc eslint rule](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-12)
  1. [Fix all internal JSDoc comments](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-13)
  1. [Convert require calls to imports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-14)
  1. [Remove typescriptServices, protocol.d.ts, typescript_standalone.d.ts](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-15)
  1. [Get codebase building pre bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-16)
  1. [Add build via esbuild](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-17)
  1. [Add dts bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-18)
  1. [Consolidate checks that test if the current environment is Node](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-19)
  1. [Add ts to globalThis in run.js for convenience during debugging](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-20)
  1. [Rename Gulpfile to Herebyfile for improved git diff](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-21)
  1. [Change build system to hereby](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-22)
  1. [Update baselines for corrected line endings in lib files](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-23)
  1. [Use jsonc-parser instead of LKG compiler in build](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-24)
  1. [Modernize localize script, use new XML library](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-25)
  1. [Don't use needsUpdate for quick tasks](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-26)
  1. [Remove mkdirp](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-27)
  1. [Export ts namespace from tsserver for hacky-post patching](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-28)
  1. [Directly import namespaces for improved esbuild output](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-29)
  1. [Ensure ts object passed to plugins contains deprecatedCompat declarations](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-30)
  1. [Move compiler-debug into Debug namespace, which allows the compiler to be tree shaken](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-31)
  1. [Remove Promise redeclaration](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-32)
  1. [Remove globalThisShim and globalThis modification for TypeScriptServicesFactory](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-33)
  1. [Disable slow CodeQL queries](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-34)
  1. [Remove outFiles from launch.json](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-35)
  1. [Remove dynamicImport and setDynamicImport](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-36)