### PR TITLE
Consolidate checks that test if the current environment is Node

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2914,3 +2914,19 @@ function trimEndImpl(s: string) {
     }
     return s.slice(0, end + 1);
 }
+
+declare const process: any;
+
+/** @internal */
+export function isNodeLikeSystem(): boolean {
+    // This is defined here rather than in sys.ts to prevent a cycle from its
+    // use in performanceCore.ts.
+    //
+    // We don't use the presence of `require` to check if we are in Node;
+    // when bundled using esbuild, this function will be rewritten to `__require`
+    // and definitely exist.
+    return typeof process !== "undefined"
+        && process.nextTick
+        && !process.browser
+        && typeof module === "object";
+}

--- a/src/compiler/performanceCore.ts
+++ b/src/compiler/performanceCore.ts
@@ -1,4 +1,4 @@
-import { Version, VersionRange } from "./_namespaces/ts";
+import { isNodeLikeSystem, Version, VersionRange } from "./_namespaces/ts";
 
 // The following definitions provide the minimum compatible support for the Web Performance User Timings API
 // between browsers and NodeJS:
@@ -80,7 +80,7 @@ function tryGetWebPerformanceHooks(): PerformanceHooks | undefined {
 }
 
 function tryGetNodePerformanceHooks(): PerformanceHooks | undefined {
-    if (typeof process !== "undefined" && process.nextTick && !process.browser && typeof module === "object" && typeof require === "function") {
+    if (isNodeLikeSystem()) {
         try {
             let performance: Performance;
             const { performance: nodePerformance, PerformanceObserver } = require("perf_hooks") as typeof import("perf_hooks");

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -2,7 +2,7 @@ import {
     AssertionLevel, closeFileWatcher, closeFileWatcherOf, combinePaths, Comparison, contains, containsPath,
     createGetCanonicalFileName, createMultiMap, Debug, directorySeparator, emptyArray, emptyFileSystemEntries, endsWith,
     enumerateInsertsAndDeletes, ESMap, FileSystemEntries, getDirectoryPath, getFallbackOptions,
-    getNormalizedAbsolutePath, getRelativePathToDirectoryOrUrl, getRootLength, getStringComparer, isArray, isString,
+    getNormalizedAbsolutePath, getRelativePathToDirectoryOrUrl, getRootLength, getStringComparer, isArray, isNodeLikeSystem, isString,
     Map, mapDefined, matchesExclude, matchFiles, memoize, noop, normalizePath, normalizeSlashes, orderedRemoveItem,
     Path, perfLogger, PollingWatchKind, RequireResult, resolveJSModule, some, startsWith, stringContains, timestamp,
     unorderedRemoveItem, WatchDirectoryKind, WatchFileKind, WatchOptions, writeFileEnsuringDirectories,
@@ -1974,9 +1974,7 @@ export let sys: System = (() => {
     }
 
     let sys: System | undefined;
-    if (typeof process !== "undefined" && process.nextTick && !process.browser && typeof require !== "undefined") {
-        // process and process.nextTick checks if current environment is node-like
-        // process.browser check excludes webpack and browserify
+    if (isNodeLikeSystem()) {
         sys = getNodeSystem();
     }
     if (sys) {

--- a/src/services/globalThisShim.ts
+++ b/src/services/globalThisShim.ts
@@ -1,4 +1,4 @@
-import { TypeScriptServicesFactory, versionMajorMinor } from "./_namespaces/ts";
+import { isNodeLikeSystem, TypeScriptServicesFactory, versionMajorMinor } from "./_namespaces/ts";
 
 // We polyfill `globalThis` here so re can reliably patch the global scope
 // in the contexts we want to in the same way across script and module formats
@@ -47,7 +47,7 @@ declare global {
 
 // if `process` is undefined, we're probably not running in node - patch legacy members onto the global scope
 // @ts-ignore
-if (typeof process === "undefined" || process.browser) {
+if (!isNodeLikeSystem()) {
     /// TODO: this is used by VS, clean this up on both sides of the interface
 
     //@ts-ignore


### PR DESCRIPTION
When bundled, it's very likely that the function "require" will actually
exist at runtime, so we can't use this to determine if we are running in
Node. Consolidate that logic and use other things to check instead.

This is still not perfectly accurate, but I don't want to change this
_too_ much, lest someone downstream depend on our inconsistent logic.

There are yet other places this commit does not fix; search for "typeof
process" for more examples.

---

**Please do not comment on this PR**. Depending on how this set of PRs evolves, this PR's contents may change entirely based on the order of commits.

This PR is a part of a stack:

  1. [Make a few changes to allow all code to be loaded as one project](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-1)
  1. [Explicitly reference ts namespace in tsserverlibrary](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-2)
  1. [Generated module conversion step - unindent](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-3)
  1. [Generated module conversion step - explicitify](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-4)
  1. [Generated module conversion step - stripNamespaces](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-5)
  1. [Generated module conversion step - inlineImports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-6)
  1. [Generated module conversion step - .git-ignore-blame-revs](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-7)
  1. [Add gitlens settings suggestion](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-8)
  1. [Make processDiagnosticMessages generate a module](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-9)
  1. [Fix up linting, make lint clean](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-10)
  1. [Undo changes needed to load codebase into ts-morph](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-11)
  1. [Add JSDoc eslint rule](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-12)
  1. [Fix all internal JSDoc comments](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-13)
  1. [Convert require calls to imports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-14)
  1. [Remove typescriptServices, protocol.d.ts, typescript_standalone.d.ts](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-15)
  1. [Get codebase building pre bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-16)
  1. [Add build via esbuild](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-17)
  1. [Add dts bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-18)
  1. Consolidate checks that test if the current environment is Node (this PR)
  1. [Add ts to globalThis in run.js for convenience during debugging](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-20)
  1. [Rename Gulpfile to Herebyfile for improved git diff](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-21)
  1. [Change build system to hereby](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-22)
  1. [Update baselines for corrected line endings in lib files](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-23)
  1. [Use jsonc-parser instead of LKG compiler in build](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-24)
  1. [Modernize localize script, use new XML library](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-25)
  1. [Don't use needsUpdate for quick tasks](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-26)
  1. [Remove mkdirp](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-27)
  1. [Export ts namespace from tsserver for hacky-post patching](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-28)
  1. [Directly import namespaces for improved esbuild output](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-29)
  1. [Ensure ts object passed to plugins contains deprecatedCompat declarations](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-30)
  1. [Move compiler-debug into Debug namespace, which allows the compiler to be tree shaken](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-31)
  1. [Remove Promise redeclaration](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-32)
  1. [Remove globalThisShim and globalThis modification for TypeScriptServicesFactory](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-33)
  1. [Disable slow CodeQL queries](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-34)
  1. [Remove outFiles from launch.json](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-35)
  1. [Remove dynamicImport and setDynamicImport](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-36)