### PR TITLE
Use jsonc-parser instead of LKG compiler in build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
                 "fs-extra": "^9.1.0",
                 "glob": "latest",
                 "hereby": "^1.6.4",
+                "jsonc-parser": "^3.2.0",
                 "minimist": "latest",
                 "mkdirp": "latest",
                 "mocha": "latest",
@@ -3019,6 +3020,12 @@
             "bin": {
                 "json5": "lib/cli.js"
             }
+        },
+        "node_modules/jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "dev": true
         },
         "node_modules/jsonfile": {
             "version": "6.1.0",
@@ -6620,6 +6627,12 @@
             "requires": {
                 "minimist": "^1.2.0"
             }
+        },
+        "jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "dev": true
         },
         "jsonfile": {
             "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "fs-extra": "^9.1.0",
         "glob": "latest",
         "hereby": "^1.6.4",
+        "jsonc-parser": "^3.2.0",
         "minimist": "latest",
         "mkdirp": "latest",
         "mocha": "latest",

--- a/scripts/build/utils.mjs
+++ b/scripts/build/utils.mjs
@@ -2,11 +2,11 @@
 
 import fs from "fs";
 import path from "path";
-import ts from "../../lib/typescript.js";
 import chalk from "chalk";
 import which from "which";
 import { spawn } from "child_process";
 import assert from "assert";
+import JSONC from "jsonc-parser";
 
 /**
  * Executes the provided command once with the supplied arguments.
@@ -47,47 +47,12 @@ export async function exec(cmd, args, options = {}) {
 }
 
 /**
- * @param {ts.Diagnostic[]} diagnostics
- * @param {{ cwd?: string, pretty?: boolean }} [options]
- */
-function formatDiagnostics(diagnostics, options) {
-    return options && options.pretty
-        ? ts.formatDiagnosticsWithColorAndContext(diagnostics, getFormatDiagnosticsHost(options && options.cwd))
-        : ts.formatDiagnostics(diagnostics, getFormatDiagnosticsHost(options && options.cwd));
-}
-
-/**
- * @param {ts.Diagnostic[]} diagnostics
- * @param {{ cwd?: string }} [options]
- */
-function reportDiagnostics(diagnostics, options) {
-    console.log(formatDiagnostics(diagnostics, { cwd: options && options.cwd, pretty: process.stdout.isTTY }));
-}
-
-/**
- * @param {string | undefined} cwd
- * @returns {ts.FormatDiagnosticsHost}
- */
-function getFormatDiagnosticsHost(cwd) {
-    return {
-        getCanonicalFileName: fileName => fileName,
-        getCurrentDirectory: () => cwd ?? process.cwd(),
-        getNewLine: () => ts.sys.newLine,
-    };
-}
-
-/**
  * Reads JSON data with optional comments using the LKG TypeScript compiler
  * @param {string} jsonPath
  */
 export function readJson(jsonPath) {
     const jsonText = fs.readFileSync(jsonPath, "utf8");
-    const result = ts.parseConfigFileTextToJson(jsonPath, jsonText);
-    if (result.error) {
-        reportDiagnostics([result.error]);
-        throw new Error("An error occurred during parse.");
-    }
-    return result.config;
+    return JSONC.parse(jsonText);
 }
 
 /**


### PR DESCRIPTION
Profiling the build roughly half of the time spent loading the
build is spent importing typescript.js, for this one function.

Since this stack is already adding required devDependencies, switch
readJson to use jsonc-parser (published by the VS Code team), rather
than importing the entire LKG typescript.js library.

---

**Please do not comment on this PR**. Depending on how this set of PRs evolves, this PR's contents may change entirely based on the order of commits.

This PR is a part of a stack:

  1. [Make a few changes to allow all code to be loaded as one project](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-1)
  1. [Explicitly reference ts namespace in tsserverlibrary](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-2)
  1. [Generated module conversion step - unindent](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-3)
  1. [Generated module conversion step - explicitify](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-4)
  1. [Generated module conversion step - stripNamespaces](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-5)
  1. [Generated module conversion step - inlineImports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-6)
  1. [Generated module conversion step - .git-ignore-blame-revs](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-7)
  1. [Add gitlens settings suggestion](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-8)
  1. [Make processDiagnosticMessages generate a module](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-9)
  1. [Fix up linting, make lint clean](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-10)
  1. [Undo changes needed to load codebase into ts-morph](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-11)
  1. [Add JSDoc eslint rule](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-12)
  1. [Fix all internal JSDoc comments](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-13)
  1. [Convert require calls to imports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-14)
  1. [Remove typescriptServices, protocol.d.ts, typescript_standalone.d.ts](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-15)
  1. [Get codebase building pre bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-16)
  1. [Add build via esbuild](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-17)
  1. [Add dts bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-18)
  1. [Consolidate checks that test if the current environment is Node](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-19)
  1. [Add ts to globalThis in run.js for convenience during debugging](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-20)
  1. [Rename Gulpfile to Herebyfile for improved git diff](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-21)
  1. [Change build system to hereby](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-22)
  1. [Update baselines for corrected line endings in lib files](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-23)
  1. Use jsonc-parser instead of LKG compiler in build (this PR)
  1. [Modernize localize script, use new XML library](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-25)
  1. [Don't use needsUpdate for quick tasks](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-26)
  1. [Remove mkdirp](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-27)
  1. [Export ts namespace from tsserver for hacky-post patching](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-28)
  1. [Directly import namespaces for improved esbuild output](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-29)
  1. [Ensure ts object passed to plugins contains deprecatedCompat declarations](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-30)
  1. [Move compiler-debug into Debug namespace, which allows the compiler to be tree shaken](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-31)
  1. [Remove Promise redeclaration](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-32)
  1. [Remove globalThisShim and globalThis modification for TypeScriptServicesFactory](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-33)
  1. [Disable slow CodeQL queries](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-34)
  1. [Remove outFiles from launch.json](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-35)
  1. [Remove dynamicImport and setDynamicImport](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-36)