### PR TITLE
Don't use needsUpdate for quick tasks

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -6,7 +6,7 @@ import { task } from "hereby";
 import _glob from "glob";
 import util from "util";
 import chalk from "chalk";
-import { exec, readJson, needsUpdate, getDiffTool, getDirSize, memoize } from "./scripts/build/utils.mjs";
+import { exec, readJson, getDiffTool, getDirSize, memoize, needsUpdate } from "./scripts/build/utils.mjs";
 import { runConsoleTests, refBaseline, localBaseline, refRwcBaseline, localRwcBaseline } from "./scripts/build/tests.mjs";
 import { buildProject as realBuildProject, cleanProject, watchProject } from "./scripts/build/projects.mjs";
 import { localizationDirectories } from "./scripts/build/localization.mjs";
@@ -81,22 +81,18 @@ export const generateLibs = task({
     description: "Builds the library targets",
     run: async () => {
         await fs.promises.mkdir("./built/local", { recursive: true });
-        const allSources = libs().flatMap((lib) => lib.sources);
-        const allTargets = libs().flatMap((lib) => lib.target);
-        if (needsUpdate([copyrightFilename, ...allSources], allTargets)) {
-            for (const lib of libs()) {
-                let output = await copyright();
+        for (const lib of libs()) {
+            let output = await copyright();
 
-                for (const source of lib.sources) {
-                    const contents = await fs.promises.readFile(source, "utf-8");
-                    // TODO(jakebailey): "\n\n" is for compatibility with our current tests; our test baselines
-                    // are sensitive to the positions of things in the lib files. Eventually remove this,
-                    // or remove lib.d.ts line numbers from our baselines.
-                    output += "\n\n" + contents.replace(/\r\n/g, "\n");
-                }
-
-                await fs.promises.writeFile(lib.target, output);
+            for (const source of lib.sources) {
+                const contents = await fs.promises.readFile(source, "utf-8");
+                // TODO(jakebailey): "\n\n" is for compatibility with our current tests; our test baselines
+                // are sensitive to the positions of things in the lib files. Eventually remove this,
+                // or remove lib.d.ts line numbers from our baselines.
+                output += "\n\n" + contents.replace(/\r\n/g, "\n");
             }
+
+            await fs.promises.writeFile(lib.target, output);
         }
     },
 });
@@ -110,9 +106,7 @@ export const generateDiagnostics = task({
     name: "generate-diagnostics",
     description: "Generates a diagnostic file in TypeScript based on an input JSON file",
     run: async () => {
-        if (needsUpdate(diagnosticMessagesJson, [diagnosticMessagesGeneratedJson, diagnosticInformationMapTs])) {
-            await exec(process.execPath, ["scripts/processDiagnosticMessages.mjs", diagnosticMessagesJson]);
-        }
+        await exec(process.execPath, ["scripts/processDiagnosticMessages.mjs", diagnosticMessagesJson]);
     }
 });
 
@@ -410,7 +404,11 @@ export const dtsServices = task({
     name: "dts-services",
     description: "Bundles typescript.d.ts",
     dependencies: [buildServices],
-    run: () => runDtsBundler("./built/local/typescript/typescript.d.ts", "./built/local/typescript.d.ts"),
+    run: async () => {
+        if (needsUpdate("./built/local/typescript/tsconfig.tsbuildinfo", ["./built/local/typescript.d.ts", "./built/local/typescript.internal.d.ts"])) {
+            runDtsBundler("./built/local/typescript/typescript.d.ts", "./built/local/typescript.d.ts");
+        }
+    },
 });
 
 
@@ -464,7 +462,11 @@ export const dtsLssl = task({
     name: "dts-lssl",
     description: "Bundles tsserverlibrary.d.ts",
     dependencies: [buildLssl],
-    run: () => runDtsBundler("./built/local/tsserverlibrary/tsserverlibrary.d.ts", "./built/local/tsserverlibrary.d.ts")
+    run: async () => {
+        if (needsUpdate("./built/local/tsserverlibrary/tsconfig.tsbuildinfo", ["./built/local/tsserverlibrary.d.ts", "./built/local/tsserverlibrary.internal.d.ts"])) {
+            await runDtsBundler("./built/local/tsserverlibrary/tsserverlibrary.d.ts", "./built/local/tsserverlibrary.d.ts");
+        }
+    }
 });
 
 export const dts = task({
@@ -560,11 +562,9 @@ export const generateTypesMap = task({
     run: async () => {
         const source = "src/server/typesMap.json";
         const target = "built/local/typesMap.json";
-        if (needsUpdate(source, target)) {
-            const contents = await fs.promises.readFile(source, "utf-8");
-            JSON.parse(contents);
-            await fs.promises.writeFile(target, contents);
-        }
+        const contents = await fs.promises.readFile(source, "utf-8");
+        JSON.parse(contents); // Validates that the JSON parses.
+        await fs.promises.writeFile(target, contents);
     }
 });
 
@@ -577,11 +577,9 @@ const copyBuiltLocalDiagnosticMessages = task({
     name: "copy-built-local-diagnostic-messages",
     dependencies: [generateDiagnostics],
     run: async () => {
-        if (needsUpdate(diagnosticMessagesGeneratedJson, builtLocalDiagnosticMessagesGeneratedJson)) {
-            const contents = await fs.promises.readFile(diagnosticMessagesGeneratedJson, "utf-8");
-            JSON.parse(contents);
-            await fs.promises.writeFile(builtLocalDiagnosticMessagesGeneratedJson, contents);
-        }
+        const contents = await fs.promises.readFile(diagnosticMessagesGeneratedJson, "utf-8");
+        JSON.parse(contents); // Validates that the JSON parses.
+        await fs.promises.writeFile(builtLocalDiagnosticMessagesGeneratedJson, contents);
     }
 });
 


### PR DESCRIPTION
needsUpdate may be wrong when the branch changes; these ones are now so
fast thanks to being pure JS that we can just always run their contents
and be sure that the outputs are right.

---

**Please do not comment on this PR**. Depending on how this set of PRs evolves, this PR's contents may change entirely based on the order of commits.

This PR is a part of a stack:

  1. [Make a few changes to allow all code to be loaded as one project](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-1)
  1. [Explicitly reference ts namespace in tsserverlibrary](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-2)
  1. [Generated module conversion step - unindent](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-3)
  1. [Generated module conversion step - explicitify](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-4)
  1. [Generated module conversion step - stripNamespaces](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-5)
  1. [Generated module conversion step - inlineImports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-6)
  1. [Generated module conversion step - .git-ignore-blame-revs](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-7)
  1. [Add gitlens settings suggestion](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-8)
  1. [Make processDiagnosticMessages generate a module](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-9)
  1. [Fix up linting, make lint clean](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-10)
  1. [Undo changes needed to load codebase into ts-morph](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-11)
  1. [Add JSDoc eslint rule](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-12)
  1. [Fix all internal JSDoc comments](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-13)
  1. [Convert require calls to imports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-14)
  1. [Remove typescriptServices, protocol.d.ts, typescript_standalone.d.ts](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-15)
  1. [Get codebase building pre bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-16)
  1. [Add build via esbuild](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-17)
  1. [Add dts bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-18)
  1. [Consolidate checks that test if the current environment is Node](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-19)
  1. [Add ts to globalThis in run.js for convenience during debugging](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-20)
  1. [Rename Gulpfile to Herebyfile for improved git diff](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-21)
  1. [Change build system to hereby](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-22)
  1. [Update baselines for corrected line endings in lib files](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-23)
  1. [Use jsonc-parser instead of LKG compiler in build](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-24)
  1. [Modernize localize script, use new XML library](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-25)
  1. Don't use needsUpdate for quick tasks (this PR)
  1. [Remove mkdirp](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-27)
  1. [Export ts namespace from tsserver for hacky-post patching](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-28)
  1. [Directly import namespaces for improved esbuild output](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-29)
  1. [Ensure ts object passed to plugins contains deprecatedCompat declarations](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-30)
  1. [Move compiler-debug into Debug namespace, which allows the compiler to be tree shaken](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-31)
  1. [Remove Promise redeclaration](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-32)
  1. [Remove globalThisShim and globalThis modification for TypeScriptServicesFactory](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-33)
  1. [Disable slow CodeQL queries](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-34)
  1. [Remove outFiles from launch.json](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-35)
  1. [Remove dynamicImport and setDynamicImport](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-36)