### PR TITLE
Export ts namespace from tsserver for hacky-post patching

### DIFF
--- a/src/tsserver/_namespaces/ts.server.ts
+++ b/src/tsserver/_namespaces/ts.server.ts
@@ -5,4 +5,4 @@ export * from "../../server/_namespaces/ts.server";
 export * from "../../webServer/_namespaces/ts.server";
 export * from "../nodeServer";
 export * from "../webServer";
-export * from "../server";
+export * from "../common";

--- a/src/tsserver/common.ts
+++ b/src/tsserver/common.ts
@@ -1,0 +1,27 @@
+import {
+    Logger, LogLevel, ServerCancellationToken, StartSessionOptions,
+} from "./_namespaces/ts.server";
+import { LanguageServiceMode } from "./_namespaces/ts";
+
+/** @internal */
+export function getLogLevel(level: string | undefined) {
+    if (level) {
+        const l = level.toLowerCase();
+        for (const name in LogLevel) {
+            if (isNaN(+name) && l === name.toLowerCase()) {
+                return LogLevel[name] as any as LogLevel;
+            }
+        }
+    }
+    return undefined;
+}
+
+/** @internal */
+export interface StartInput {
+    args: readonly string[];
+    logger: Logger;
+    cancellationToken: ServerCancellationToken;
+    serverMode: LanguageServiceMode | undefined;
+    unknownServerMode?: string;
+    startSession: (option: StartSessionOptions, logger: Logger, cancellationToken: ServerCancellationToken) => void;
+}

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -1,8 +1,9 @@
 import {
-    emptyArray, findArgument, hasArgument, initializeNodeSystem, initializeWebSystem, Logger, LogLevel, Msg,
-    ServerCancellationToken, StartSessionOptions,
+    emptyArray, findArgument, hasArgument, initializeNodeSystem, initializeWebSystem, Msg,
+    StartInput,
 } from "./_namespaces/ts.server";
-import { Debug, getNodeMajorVersion, LanguageServiceMode, setStackTraceLimit, sys, version } from "./_namespaces/ts";
+import { Debug, getNodeMajorVersion, setStackTraceLimit, sys, version } from "./_namespaces/ts";
+export * from "./_namespaces/ts";
 
 declare const addEventListener: any;
 declare const removeEventListener: any;
@@ -14,28 +15,7 @@ function findArgumentStringArray(argName: string): readonly string[] {
     return arg.split(",").filter(name => name !== "");
 }
 
-/** @internal */
-export function getLogLevel(level: string | undefined) {
-    if (level) {
-        const l = level.toLowerCase();
-        for (const name in LogLevel) {
-            if (isNaN(+name) && l === name.toLowerCase()) {
-                return LogLevel[name] as any as LogLevel;
-            }
-        }
-    }
-    return undefined;
-}
 
-/** @internal */
-export interface StartInput {
-    args: readonly string[];
-    logger: Logger;
-    cancellationToken: ServerCancellationToken;
-    serverMode: LanguageServiceMode | undefined;
-    unknownServerMode?: string;
-    startSession: (option: StartSessionOptions, logger: Logger, cancellationToken: ServerCancellationToken) => void;
-}
 function start({ args, logger, cancellationToken, serverMode, unknownServerMode, startSession: startServer }: StartInput, platform: string) {
     const syntaxOnly = hasArgument("--syntaxOnly");
 


### PR DESCRIPTION
Unlike our other exectuables, tsserver is used in web, which means that
there actually would have been a "ts" variable declared for those users
(e.g. in a web worker). It looks like VS Code needs this variable to be
declared, so change this bundle to look the same as other libraries.

Note that in Node, the IIFE will never actually return, so this can have
no effect. On web, it will return in order to yield control back to the
event loop (as on web, postMessage is used to communicate).

---

**Please do not comment on this PR**. Depending on how this set of PRs evolves, this PR's contents may change entirely based on the order of commits.

This PR is a part of a stack:

  1. [Make a few changes to allow all code to be loaded as one project](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-1)
  1. [Explicitly reference ts namespace in tsserverlibrary](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-2)
  1. [Generated module conversion step - unindent](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-3)
  1. [Generated module conversion step - explicitify](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-4)
  1. [Generated module conversion step - stripNamespaces](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-5)
  1. [Generated module conversion step - inlineImports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-6)
  1. [Generated module conversion step - .git-ignore-blame-revs](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-7)
  1. [Add gitlens settings suggestion](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-8)
  1. [Make processDiagnosticMessages generate a module](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-9)
  1. [Fix up linting, make lint clean](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-10)
  1. [Undo changes needed to load codebase into ts-morph](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-11)
  1. [Add JSDoc eslint rule](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-12)
  1. [Fix all internal JSDoc comments](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-13)
  1. [Convert require calls to imports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-14)
  1. [Remove typescriptServices, protocol.d.ts, typescript_standalone.d.ts](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-15)
  1. [Get codebase building pre bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-16)
  1. [Add build via esbuild](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-17)
  1. [Add dts bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-18)
  1. [Consolidate checks that test if the current environment is Node](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-19)
  1. [Add ts to globalThis in run.js for convenience during debugging](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-20)
  1. [Rename Gulpfile to Herebyfile for improved git diff](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-21)
  1. [Change build system to hereby](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-22)
  1. [Update baselines for corrected line endings in lib files](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-23)
  1. [Use jsonc-parser instead of LKG compiler in build](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-24)
  1. [Modernize localize script, use new XML library](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-25)
  1. [Don't use needsUpdate for quick tasks](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-26)
  1. [Remove mkdirp](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-27)
  1. Export ts namespace from tsserver for hacky-post patching (this PR)
  1. [Directly import namespaces for improved esbuild output](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-29)
  1. [Ensure ts object passed to plugins contains deprecatedCompat declarations](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-30)
  1. [Move compiler-debug into Debug namespace, which allows the compiler to be tree shaken](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-31)
  1. [Remove Promise redeclaration](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-32)
  1. [Remove globalThisShim and globalThis modification for TypeScriptServicesFactory](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-33)
  1. [Disable slow CodeQL queries](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-34)
  1. [Remove outFiles from launch.json](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-35)
  1. [Remove dynamicImport and setDynamicImport](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-36)