### PR TITLE
Directly import namespaces for improved esbuild output

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,5 @@
 **/node_modules/**
-/built/local/**
+/built/**
 /tests/**
 /lib/**
 /src/lib/*.generated.d.ts

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -6,7 +6,21 @@
     },
     "rules": {
         "@typescript-eslint/no-unnecessary-qualifier": "error",
-        "@typescript-eslint/no-unnecessary-type-assertion": "error"
+        "@typescript-eslint/no-unnecessary-type-assertion": "error",
+        "no-restricted-globals": ["error",
+            { "name": "setTimeout" },
+            { "name": "clearTimeout" },
+            { "name": "setInterval" },
+            { "name": "clearInterval" },
+            { "name": "setImmediate" },
+            { "name": "clearImmediate" },
+            { "name": "performance" },
+            { "name": "Iterator" },
+            { "name": "Map" },
+            { "name": "ReadonlyMap" },
+            { "name": "Set" },
+            { "name": "ReadonlySet" }
+        ]
     },
     "overrides": [
         {
@@ -20,13 +34,20 @@
                 "local/no-keywords": "off",
 
                 // eslint
-                "no-var": "off"
+                "no-var": "off",
+                "no-restricted-globals": "off"
             }
         },
         {
             "files": ["lib/es2019.array.d.ts"],
             "rules": {
                 "@typescript-eslint/array-type": "off"
+            }
+        },
+        {
+            "files": ["debug/**", "harness/**", "testRunner/**"],
+            "rules": {
+                "no-restricted-globals": "off"
             }
         }
     ]

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1,4 +1,3 @@
-import * as ts from "./_namespaces/ts";
 import {
     __String, AccessExpression, addRelatedInfo, append, appendIfUnique, ArrayBindingElement, ArrayLiteralExpression,
     ArrowFunction, AssignmentDeclarationKind, BinaryExpression, BinaryOperatorToken, BindableAccessExpression,
@@ -59,6 +58,7 @@ import {
     TypeLiteralNode, TypeOfExpression, TypeParameterDeclaration, unescapeLeadingUnderscores, unreachableCodeIsError,
     unusedLabelIsError, VariableDeclaration, WhileStatement, WithStatement,
 } from "./_namespaces/ts";
+import * as performance from "./_namespaces/ts.performance";
 
 /** @internal */
 export const enum ModuleInstanceState {
@@ -236,12 +236,12 @@ const binder = createBinder();
 
 /** @internal */
 export function bindSourceFile(file: SourceFile, options: CompilerOptions) {
-    ts.performance.mark("beforeBind");
+    performance.mark("beforeBind");
     perfLogger.logStartBindFile("" + file.fileName);
     binder(file, options);
     perfLogger.logStopBindFile();
-    ts.performance.mark("afterBind");
-    ts.performance.measure("Bind", "beforeBind", "afterBind");
+    performance.mark("afterBind");
+    performance.measure("Bind", "beforeBind", "afterBind");
 }
 
 function createBinder(): (file: SourceFile, options: CompilerOptions) => void {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -155,7 +155,7 @@ import {
     mapDefined, MappedSymbol, MappedType, MappedTypeNode, MatchingKeys, maybeBind, MemberName, MemberOverrideStatus,
     memoize, MetaProperty, MethodDeclaration, MethodSignature, minAndMax, MinusToken, Modifier, ModifierFlags,
     modifiersToFlags, modifierToFlag, ModuleBlock, ModuleDeclaration, ModuleInstanceState, ModuleKind,
-    ModuleResolutionKind, moduleSpecifiers, NamedDeclaration, NamedExports, NamedImportsOrExports, NamedTupleMember,
+    ModuleResolutionKind, NamedDeclaration, NamedExports, NamedImportsOrExports, NamedTupleMember,
     NamespaceDeclaration, NamespaceExport, NamespaceExportDeclaration, NamespaceImport, needsScopeMarker, NewExpression,
     Node, NodeArray, NodeBuilderFlags, nodeCanBeDecorated, NodeCheckFlags, NodeFlags, nodeHasName, nodeIsDecorated,
     nodeIsMissing, nodeIsPresent, nodeIsSynthesized, NodeLinks, nodeStartsNewLexicalEnvironment, NodeWithTypeArguments,
@@ -197,6 +197,8 @@ import {
     walkUpBindingElementsAndPatterns, walkUpParenthesizedExpressions, walkUpParenthesizedTypes,
     walkUpParenthesizedTypesAndGetParentAndChild, WhileStatement, WideningContext, WithStatement, YieldExpression,
 } from "./_namespaces/ts";
+import * as performance from "./_namespaces/ts.performance";
+import * as moduleSpecifiers from "./_namespaces/ts.moduleSpecifiers";
 
 const ambientModuleSymbolRegex = /^".+"$/;
 const anon = "(anonymous)" as __String & string;
@@ -42552,10 +42554,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function checkSourceFile(node: SourceFile) {
         tracing?.push(tracing.Phase.Check, "checkSourceFile", { path: node.path }, /*separateBeginAndEnd*/ true);
-        ts.performance.mark("beforeCheck");
+        performance.mark("beforeCheck");
         checkSourceFileWorker(node);
-        ts.performance.mark("afterCheck");
-        ts.performance.measure("Check", "beforeCheck", "afterCheck");
+        performance.mark("afterCheck");
+        performance.measure("Check", "beforeCheck", "afterCheck");
         tracing?.pop();
     }
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -79,6 +79,7 @@ import {
     VariableDeclaration, VariableDeclarationList, VariableStatement, VoidExpression, WhileStatement, WithStatement,
     writeCommentRange, writeFile, WriteFileCallbackData, YieldExpression,
 } from "./_namespaces/ts";
+import * as performance from "./_namespaces/ts.performance";
 
 const brackets = createBracketsMap();
 
@@ -367,7 +368,7 @@ export function emitFiles(resolver: EmitResolver, host: EmitHost, targetSourceFi
     const emitterDiagnostics = createDiagnosticCollection();
     const newLine = getNewLineCharacter(compilerOptions, () => host.getNewLine());
     const writer = createTextWriter(newLine);
-    const { enter, exit } = ts.performance.createTimer("printTime", "beforePrint", "afterPrint");
+    const { enter, exit } = performance.createTimer("printTime", "beforePrint", "afterPrint");
     let bundleBuildInfo: BundleBuildInfo | undefined;
     let emitSkipped = false;
 
@@ -1030,7 +1031,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
     let commentsDisabled = !!printerOptions.removeComments;
     let lastSubstitution: Node | undefined;
     let currentParenthesizerRule: ((node: Node) => Node) | undefined;
-    const { enter: enterComment, exit: exitComment } = ts.performance.createTimerIf(extendedDiagnostics, "commentTime", "beforeComment", "afterComment");
+    const { enter: enterComment, exit: exitComment } = performance.createTimerIf(extendedDiagnostics, "commentTime", "beforeComment", "afterComment");
     const parenthesizer = factory.parenthesizer;
     const typeArgumentParenthesizerRuleSelector: OrdinalParentheizerRuleSelector<Node> = {
         select: index => index === 0 ? parenthesizer.parenthesizeLeadingTypeArgument : undefined

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -65,6 +65,7 @@ import {
     UnionOrIntersectionTypeNode, UnionTypeNode, UpdateExpression, VariableDeclaration, VariableDeclarationList,
     VariableStatement, VoidExpression, WhileStatement, WithStatement, YieldExpression,
 } from "./_namespaces/ts";
+import * as performance from "./_namespaces/ts.performance";
 
 const enum SignatureFlags {
     None = 0,
@@ -1005,7 +1006,7 @@ function setExternalModuleIndicator(sourceFile: SourceFile) {
 
 export function createSourceFile(fileName: string, sourceText: string, languageVersionOrOptions: ScriptTarget | CreateSourceFileOptions, setParentNodes = false, scriptKind?: ScriptKind): SourceFile {
     tracing?.push(tracing.Phase.Parse, "createSourceFile", { path: fileName }, /*separateBeginAndEnd*/ true);
-    ts.performance.mark("beforeParse");
+    performance.mark("beforeParse");
     let result: SourceFile;
 
     perfLogger.logStartParseSourceFile(fileName);
@@ -1026,8 +1027,8 @@ export function createSourceFile(fileName: string, sourceText: string, languageV
     }
     perfLogger.logStopParseSourceFile();
 
-    ts.performance.mark("afterParse");
-    ts.performance.measure("Parse", "beforeParse", "afterParse");
+    performance.mark("afterParse");
+    performance.measure("Parse", "beforeParse", "afterParse");
     tracing?.pop();
     return result;
 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -60,6 +60,7 @@ import {
     VariableStatement, walkUpParenthesizedExpressions, WriteFileCallback, WriteFileCallbackData,
     writeFileEnsuringDirectories, zipToModeAwareCache,
 } from "./_namespaces/ts";
+import * as performance from "./_namespaces/ts.performance";
 
 export function findConfigFile(searchPath: string, fileExists: (fileName: string) => boolean, configName = "tsconfig.json"): string | undefined {
     return forEachAncestorDirectory(searchPath, ancestor => {
@@ -133,10 +134,10 @@ export function createGetSourceFile(
     return (fileName, languageVersionOrOptions, onError) => {
         let text: string | undefined;
         try {
-            ts.performance.mark("beforeIORead");
+            performance.mark("beforeIORead");
             text = readFile(fileName, getCompilerOptions().charset);
-            ts.performance.mark("afterIORead");
-            ts.performance.measure("I/O Read", "beforeIORead", "afterIORead");
+            performance.mark("afterIORead");
+            performance.measure("I/O Read", "beforeIORead", "afterIORead");
         }
         catch (e) {
             if (onError) {
@@ -156,7 +157,7 @@ export function createWriteFileMeasuringIO(
 ): CompilerHost["writeFile"] {
     return (fileName, data, writeByteOrderMark, onError) => {
         try {
-            ts.performance.mark("beforeIOWrite");
+            performance.mark("beforeIOWrite");
 
             // NOTE: If patchWriteFileEnsuringDirectory has been called,
             // the system.writeFile will do its own directory creation and
@@ -170,8 +171,8 @@ export function createWriteFileMeasuringIO(
                 directoryExists
             );
 
-            ts.performance.mark("afterIOWrite");
-            ts.performance.measure("I/O Write", "beforeIOWrite", "afterIOWrite");
+            performance.mark("afterIOWrite");
+            performance.measure("I/O Write", "beforeIOWrite", "afterIOWrite");
         }
         catch (e) {
             if (onError) {
@@ -1145,7 +1146,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
     const sourceFilesFoundSearchingNodeModules = new Map<string, boolean>();
 
     tracing?.push(tracing.Phase.Program, "createProgram", { configFilePath: options.configFilePath, rootDir: options.rootDir }, /*separateBeginAndEnd*/ true);
-    ts.performance.mark("beforeProgram");
+    performance.mark("beforeProgram");
 
     const host = createProgramOptions.host || createCompilerHost(options);
     const configParsingHost = parseConfigHostFromCompilerHostLike(host);
@@ -1468,8 +1469,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
     });
 
     verifyCompilerOptions();
-    ts.performance.mark("afterProgram");
-    ts.performance.measure("Program", "beforeProgram", "afterProgram");
+    performance.mark("afterProgram");
+    performance.measure("Program", "beforeProgram", "afterProgram");
     tracing?.pop();
 
     return program;
@@ -1506,10 +1507,10 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         const containingFileName = getNormalizedAbsolutePath(containingFile.originalFileName, currentDirectory);
         const redirectedReference = getRedirectReferenceForResolution(containingFile);
         tracing?.push(tracing.Phase.Program, "resolveModuleNamesWorker", { containingFileName });
-        ts.performance.mark("beforeResolveModule");
+        performance.mark("beforeResolveModule");
         const result = actualResolveModuleNamesWorker(moduleNames, containingFile, containingFileName, redirectedReference, resolutionInfo);
-        ts.performance.mark("afterResolveModule");
-        ts.performance.measure("ResolveModule", "beforeResolveModule", "afterResolveModule");
+        performance.mark("afterResolveModule");
+        performance.measure("ResolveModule", "beforeResolveModule", "afterResolveModule");
         tracing?.pop();
         pullDiagnosticsFromCache(moduleNames, containingFile);
         return result;
@@ -1521,10 +1522,10 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         const redirectedReference = !isString(containingFile) ? getRedirectReferenceForResolution(containingFile) : undefined;
         const containingFileMode = !isString(containingFile) ? containingFile.impliedNodeFormat : undefined;
         tracing?.push(tracing.Phase.Program, "resolveTypeReferenceDirectiveNamesWorker", { containingFileName });
-        ts.performance.mark("beforeResolveTypeReference");
+        performance.mark("beforeResolveTypeReference");
         const result = actualResolveTypeReferenceDirectiveNamesWorker(typeDirectiveNames, containingFileName, redirectedReference, containingFileMode);
-        ts.performance.mark("afterResolveTypeReference");
-        ts.performance.measure("ResolveTypeReference", "beforeResolveTypeReference", "afterResolveTypeReference");
+        performance.mark("afterResolveTypeReference");
+        performance.measure("ResolveTypeReference", "beforeResolveTypeReference", "afterResolveTypeReference");
         tracing?.pop();
         return result;
     }
@@ -2067,7 +2068,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
     function emitBuildInfo(writeFileCallback?: WriteFileCallback): EmitResult {
         Debug.assert(!outFile(options));
         tracing?.push(tracing.Phase.Emit, "emitBuildInfo", {}, /*separateBeginAndEnd*/ true);
-        ts.performance.mark("beforeEmit");
+        performance.mark("beforeEmit");
         const emitResult = emitFiles(
             notImplementedResolver,
             getEmitHost(writeFileCallback),
@@ -2077,8 +2078,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             /*onlyBuildInfo*/ true
         );
 
-        ts.performance.mark("afterEmit");
-        ts.performance.measure("Emit", "beforeEmit", "afterEmit");
+        performance.mark("afterEmit");
+        performance.measure("Emit", "beforeEmit", "afterEmit");
         tracing?.pop();
         return emitResult;
     }
@@ -2163,7 +2164,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         // checked is to not pass the file to getEmitResolver.
         const emitResolver = getTypeChecker().getEmitResolver(outFile(options) ? undefined : sourceFile, cancellationToken);
 
-        ts.performance.mark("beforeEmit");
+        performance.mark("beforeEmit");
 
         const emitResult = emitFiles(
             emitResolver,
@@ -2175,8 +2176,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             forceDtsEmit
         );
 
-        ts.performance.mark("afterEmit");
-        ts.performance.measure("Emit", "beforeEmit", "afterEmit");
+        performance.mark("afterEmit");
+        performance.measure("Emit", "beforeEmit", "afterEmit");
         return emitResult;
     }
 

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -1,4 +1,3 @@
-import * as ts from "./_namespaces/ts";
 import {
     arrayFrom, binarySearchKey, CharacterCodes, combinePaths, compareValues, Debug, DocumentPosition,
     DocumentPositionMapper, DocumentPositionMapperHost, EmitHost, emptyArray, ESMap, every, getDirectoryPath,
@@ -6,6 +5,7 @@ import {
     isString, Iterator, LineAndCharacter, Map, RawSourceMap, some, sortAndDeduplicate, SortedReadonlyArray,
     SourceMapGenerator, trimStringEnd,
 } from "./_namespaces/ts";
+import * as performance from "./_namespaces/ts.performance";
 
 /** @internal */
 export interface SourceMapGeneratorOptions {
@@ -15,8 +15,8 @@ export interface SourceMapGeneratorOptions {
 /** @internal */
 export function createSourceMapGenerator(host: EmitHost, file: string, sourceRoot: string, sourcesDirectoryPath: string, generatorOptions: SourceMapGeneratorOptions): SourceMapGenerator {
     const { enter, exit } = generatorOptions.extendedDiagnostics
-        ? ts.performance.createTimer("Source Map", "beforeSourcemap", "afterSourcemap")
-        : ts.performance.nullTimer;
+        ? performance.createTimer("Source Map", "beforeSourcemap", "afterSourcemap")
+        : performance.nullTimer;
 
     // Current source map file and its index in the sources list
     const rawSources: string[] = [];

--- a/src/compiler/tracing.ts
+++ b/src/compiler/tracing.ts
@@ -1,9 +1,9 @@
-import * as ts from "./_namespaces/ts";
 import {
     combinePaths, ConditionalType, Debug, EvolvingArrayType, getLineAndCharacterOfPosition, getSourceFileOfNode,
     IndexedAccessType, IndexType, IntersectionType, LineAndCharacter, Map, Node, ObjectFlags, Path, ReverseMappedType,
     SubstitutionType, timestamp, Type, TypeFlags, TypeReference, unescapeLeadingUnderscores, UnionType,
 } from "./_namespaces/ts";
+import * as performance from "./_namespaces/ts.performance";
 
 /* Tracing events for the compiler. */
 
@@ -172,13 +172,13 @@ export namespace tracingEnabled {
         // In server mode, there's no easy way to dump type information, so we drop events that would require it.
         if (mode === "server" && phase === Phase.CheckTypes) return;
 
-        ts.performance.mark("beginTracing");
+        performance.mark("beginTracing");
         fs.writeSync(traceFd, `,\n{"pid":1,"tid":1,"ph":"${eventType}","cat":"${phase}","ts":${time},"name":"${name}"`);
         if (extras) fs.writeSync(traceFd, `,${extras}`);
         if (args) fs.writeSync(traceFd, `,"args":${JSON.stringify(args)}`);
         fs.writeSync(traceFd, `}`);
-        ts.performance.mark("endTracing");
-        ts.performance.measure("Tracing", "beginTracing", "endTracing");
+        performance.mark("endTracing");
+        performance.measure("Tracing", "beginTracing", "endTracing");
     }
 
     function getLocation(node: Node | undefined) {
@@ -200,7 +200,7 @@ export namespace tracingEnabled {
     }
 
     function dumpTypes(types: readonly Type[]) {
-        ts.performance.mark("beginDumpTypes");
+        performance.mark("beginDumpTypes");
 
         const typesPath = legend[legend.length - 1].typesPath!;
         const typesFd = fs.openSync(typesPath, "w");
@@ -329,8 +329,8 @@ export namespace tracingEnabled {
 
         fs.closeSync(typesFd);
 
-        ts.performance.mark("endDumpTypes");
-        ts.performance.measure("Dump types", "beginDumpTypes", "endDumpTypes");
+        performance.mark("endDumpTypes");
+        performance.measure("Dump types", "beginDumpTypes", "endDumpTypes");
     }
 
     export function dumpLegend() {

--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -1,4 +1,3 @@
-import * as ts from "./_namespaces/ts";
 import {
     addRange, append, Bundle, chainBundle, CompilerOptions, createEmitHelperFactory, CustomTransformer,
     CustomTransformerFactory, CustomTransformers, Debug, DiagnosticWithLocation, disposeEmitNodes, EmitFlags,
@@ -12,6 +11,7 @@ import {
     transformLegacyDecorators, transformModule, transformNodeModule, transformSystemModule, transformTypeScript,
     VariableDeclaration,
 } from "./_namespaces/ts";
+import * as performance from "./_namespaces/ts.performance";
 
 function getModuleTransformer(moduleKind: ModuleKind): TransformerFactory<SourceFile | Bundle> {
     switch (moduleKind) {
@@ -240,7 +240,7 @@ export function transformNodes<T extends Node>(resolver: EmitResolver | undefine
         disposeEmitNodes(getSourceFileOfNode(getParseTreeNode(node)));
     }
 
-    ts.performance.mark("beforeTransform");
+    performance.mark("beforeTransform");
 
     // Chain together and initialize each transformer.
     const transformersWithContext = transformers.map(t => t(context));
@@ -265,8 +265,8 @@ export function transformNodes<T extends Node>(resolver: EmitResolver | undefine
     // prevent modification of the lexical environment.
     state = TransformationState.Completed;
 
-    ts.performance.mark("afterTransform");
-    ts.performance.measure("transformTime", "beforeTransform", "afterTransform");
+    performance.mark("afterTransform");
+    performance.measure("transformTime", "beforeTransform", "afterTransform");
 
     return {
         transformed,

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -28,7 +28,7 @@ import {
     isStringANonContextualKeyword, isStringLiteral, isStringLiteralLike, isTupleTypeNode, isTypeAliasDeclaration,
     isTypeNode, isTypeParameterDeclaration, isTypeQueryNode, isUnparsedSource, last, LateBoundDeclaration,
     LateVisibilityPaintedStatement, length, map, Map, mapDefined, MethodDeclaration, MethodSignature, Modifier,
-    ModifierFlags, ModuleBody, ModuleDeclaration, moduleSpecifiers, NamedDeclaration, NamespaceDeclaration,
+    ModifierFlags, ModuleBody, ModuleDeclaration, NamedDeclaration, NamespaceDeclaration,
     needsScopeMarker, Node, NodeArray, NodeBuilderFlags, NodeFlags, NodeId, normalizeSlashes, OmittedExpression,
     orderedRemoveItem, ParameterDeclaration, parseNodeFactory, pathContainsNodeModules, pathIsRelative,
     PropertyDeclaration, PropertySignature, pushIfUnique, removeAllComments, Set, SetAccessorDeclaration,
@@ -39,6 +39,7 @@ import {
     TypeReferenceNode, unescapeLeadingUnderscores, UnparsedSource, VariableDeclaration, VariableStatement, visitArray,
     visitEachChild, visitNode, visitNodes, VisitResult,
 } from "../_namespaces/ts";
+import * as moduleSpecifiers from "../_namespaces/ts.moduleSpecifiers";
 
 /** @internal */
 export function getDeclarationDiagnostics(host: EmitHost, resolver: EmitResolver, file: SourceFile | undefined): DiagnosticWithLocation[] | undefined {

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -27,6 +27,7 @@ import {
     UpToDateStatus, UpToDateStatusType, version, WatchFactory, WatchHost, WatchOptions, WatchStatusReporter, WatchType,
     WildcardDirectoryWatcher, writeFile, WriteFileCallback,
 } from "./_namespaces/ts";
+import * as performance from "./_namespaces/ts.performance";
 
 const minimumDate = new Date(-8640000000000000);
 const maximumDate = new Date(8640000000000000);
@@ -443,7 +444,7 @@ function parseConfigFile(state: SolutionBuilderState, configFileName: ResolvedCo
         return isParsedCommandLine(value) ? value : undefined;
     }
 
-    ts.performance.mark("SolutionBuilder::beforeConfigFileParsing");
+    performance.mark("SolutionBuilder::beforeConfigFileParsing");
     let diagnostic: Diagnostic | undefined;
     const { parseConfigFileHost, baseCompilerOptions, baseWatchOptions, extendedConfigCache, host } = state;
     let parsed: ParsedCommandLine | undefined;
@@ -457,8 +458,8 @@ function parseConfigFile(state: SolutionBuilderState, configFileName: ResolvedCo
         parseConfigFileHost.onUnRecoverableConfigFileDiagnostic = noop;
     }
     configFileCache.set(configFilePath, parsed || diagnostic!);
-    ts.performance.mark("SolutionBuilder::afterConfigFileParsing");
-    ts.performance.measure("SolutionBuilder::Config file parsing", "SolutionBuilder::beforeConfigFileParsing", "SolutionBuilder::afterConfigFileParsing");
+    performance.mark("SolutionBuilder::afterConfigFileParsing");
+    performance.measure("SolutionBuilder::Config file parsing", "SolutionBuilder::beforeConfigFileParsing", "SolutionBuilder::afterConfigFileParsing");
     return parsed;
 }
 
@@ -776,7 +777,7 @@ function createUpdateOutputFileStampsProject(
             if (updateOutputFileStampsPending) {
                 updateOutputTimestamps(state, config, projectPath);
             }
-            ts.performance.mark("SolutionBuilder::Timestamps only updates");
+            performance.mark("SolutionBuilder::Timestamps only updates");
             return doneInvalidatedProject(state, projectPath);
         }
     };
@@ -890,8 +891,8 @@ function createBuildOrUpdateInvalidedProject<T extends BuilderProgram>(
 
     function done(cancellationToken?: CancellationToken, writeFile?: WriteFileCallback, customTransformers?: CustomTransformers) {
         executeSteps(BuildStep.Done, cancellationToken, writeFile, customTransformers);
-        if (kind === InvalidatedProjectKind.Build) ts.performance.mark("SolutionBuilder::Projects built");
-        else ts.performance.mark("SolutionBuilder::Bundles updated");
+        if (kind === InvalidatedProjectKind.Build) performance.mark("SolutionBuilder::Projects built");
+        else performance.mark("SolutionBuilder::Bundles updated");
         return doneInvalidatedProject(state, projectPath);
     }
 
@@ -1857,10 +1858,10 @@ function getUpToDateStatus(state: SolutionBuilderState, project: ParsedCommandLi
         return prior;
     }
 
-    ts.performance.mark("SolutionBuilder::beforeUpToDateCheck");
+    performance.mark("SolutionBuilder::beforeUpToDateCheck");
     const actual = getUpToDateStatusWorker(state, project, resolvedPath);
-    ts.performance.mark("SolutionBuilder::afterUpToDateCheck");
-    ts.performance.measure("SolutionBuilder::Up-to-date check", "SolutionBuilder::beforeUpToDateCheck", "SolutionBuilder::afterUpToDateCheck");
+    performance.mark("SolutionBuilder::afterUpToDateCheck");
+    performance.measure("SolutionBuilder::Up-to-date check", "SolutionBuilder::beforeUpToDateCheck", "SolutionBuilder::afterUpToDateCheck");
     state.projectStatus.set(resolvedPath, actual);
     return actual;
 }
@@ -2009,10 +2010,10 @@ function queueReferencingProjects(
 }
 
 function build(state: SolutionBuilderState, project?: string, cancellationToken?: CancellationToken, writeFile?: WriteFileCallback, getCustomTransformers?: (project: string) => CustomTransformers, onlyReferences?: boolean): ExitStatus {
-    ts.performance.mark("SolutionBuilder::beforeBuild");
+    performance.mark("SolutionBuilder::beforeBuild");
     const result = buildWorker(state, project, cancellationToken, writeFile, getCustomTransformers, onlyReferences);
-    ts.performance.mark("SolutionBuilder::afterBuild");
-    ts.performance.measure("SolutionBuilder::Build", "SolutionBuilder::beforeBuild", "SolutionBuilder::afterBuild");
+    performance.mark("SolutionBuilder::afterBuild");
+    performance.measure("SolutionBuilder::Build", "SolutionBuilder::beforeBuild", "SolutionBuilder::afterBuild");
     return result;
 }
 
@@ -2046,10 +2047,10 @@ function buildWorker(state: SolutionBuilderState, project: string | undefined, c
 }
 
 function clean(state: SolutionBuilderState, project?: string, onlyReferences?: boolean): ExitStatus {
-    ts.performance.mark("SolutionBuilder::beforeClean");
+    performance.mark("SolutionBuilder::beforeClean");
     const result = cleanWorker(state, project, onlyReferences);
-    ts.performance.mark("SolutionBuilder::afterClean");
-    ts.performance.measure("SolutionBuilder::Clean", "SolutionBuilder::beforeClean", "SolutionBuilder::afterClean");
+    performance.mark("SolutionBuilder::afterClean");
+    performance.measure("SolutionBuilder::Clean", "SolutionBuilder::beforeClean", "SolutionBuilder::afterClean");
     return result;
 }
 
@@ -2130,10 +2131,10 @@ function scheduleBuildInvalidatedProject(state: SolutionBuilderState, time: numb
 }
 
 function buildNextInvalidatedProject(state: SolutionBuilderState, changeDetected: boolean) {
-    ts.performance.mark("SolutionBuilder::beforeBuild");
+    performance.mark("SolutionBuilder::beforeBuild");
     const buildOrder = buildNextInvalidatedProjectWorker(state, changeDetected);
-    ts.performance.mark("SolutionBuilder::afterBuild");
-    ts.performance.measure("SolutionBuilder::Build", "SolutionBuilder::beforeBuild", "SolutionBuilder::afterBuild");
+    performance.mark("SolutionBuilder::afterBuild");
+    performance.measure("SolutionBuilder::Build", "SolutionBuilder::beforeBuild", "SolutionBuilder::afterBuild");
     if (buildOrder) reportErrorSummary(state, buildOrder);
 }
 
@@ -2274,7 +2275,7 @@ function watchPackageJsonFiles(state: SolutionBuilderState, resolved: ResolvedCo
 
 function startWatching(state: SolutionBuilderState, buildOrder: AnyBuildOrder) {
     if (!state.watchAllProjectsPending) return;
-    ts.performance.mark("SolutionBuilder::beforeWatcherCreation");
+    performance.mark("SolutionBuilder::beforeWatcherCreation");
     state.watchAllProjectsPending = false;
     for (const resolved of getBuildOrderFromAnyBuildOrder(buildOrder)) {
         const resolvedPath = toResolvedConfigFilePath(state, resolved);
@@ -2293,8 +2294,8 @@ function startWatching(state: SolutionBuilderState, buildOrder: AnyBuildOrder) {
             watchPackageJsonFiles(state, resolved, resolvedPath, cfg);
         }
     }
-    ts.performance.mark("SolutionBuilder::afterWatcherCreation");
-    ts.performance.measure("SolutionBuilder::Watcher creation", "SolutionBuilder::beforeWatcherCreation", "SolutionBuilder::afterWatcherCreation");
+    performance.mark("SolutionBuilder::afterWatcherCreation");
+    performance.measure("SolutionBuilder::Watcher creation", "SolutionBuilder::beforeWatcherCreation", "SolutionBuilder::afterWatcherCreation");
 }
 
 function stopWatching(state: SolutionBuilderState) {

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -18,6 +18,7 @@ import {
     supportedJSExtensionsFlat, supportedTSExtensionsFlat, sys, System, toPath, tracing, validateLocaleAndSetLanguage,
     version, WatchCompilerHost, WatchOptions,
 } from "./_namespaces/ts";
+import * as performance from "../compiler/_namespaces/ts.performance";
 
 interface Statistic {
     name: string;
@@ -967,7 +968,7 @@ interface SolutionPerformance {
 
 function enableSolutionPerformance(system: System, options: BuildOptions) {
     if (system === sys && options.extendedDiagnostics) {
-        ts.performance.enable();
+        performance.enable();
         return createSolutionPerfomrance();
     }
 }
@@ -1005,7 +1006,7 @@ function reportSolutionBuilderTimes(
     solutionPerformance: SolutionPerformance | undefined) {
     if (!solutionPerformance) return;
 
-    if (!ts.performance.isEnabled()) {
+    if (!performance.isEnabled()) {
         sys.write(Diagnostics.Performance_timings_for_diagnostics_or_extendedDiagnostics_are_not_available_in_this_session_A_native_implementation_of_the_Web_Performance_API_could_not_be_found.message + "\n");
         return;
     }
@@ -1021,17 +1022,17 @@ function reportSolutionBuilderTimes(
         s.name = `Aggregate ${s.name}`;
         statistics.push(s);
     });
-    ts.performance.forEachMeasure((name, duration) => {
+    performance.forEachMeasure((name, duration) => {
         if (isSolutionMarkOrMeasure(name)) statistics.push({ name: `${getNameFromSolutionBuilderMarkOrMeasure(name)} time`, value: duration, type: StatisticType.time });
     });
-    ts.performance.disable();
-    ts.performance.enable();
+    performance.disable();
+    performance.enable();
     solutionPerformance.clear();
 
     reportAllStatistics(sys, statistics);
 
     function reportSolutionBuilderCountStatistic(name: string) {
-        const value = ts.performance.getCount(name);
+        const value = performance.getCount(name);
         if (value) {
             statistics.push({ name: getNameFromSolutionBuilderMarkOrMeasure(name), value, type: StatisticType.count });
         }
@@ -1052,7 +1053,7 @@ function canTrace(system: System, compilerOptions: CompilerOptions) {
 
 function enableStatisticsAndTracing(system: System, compilerOptions: CompilerOptions, isBuildMode: boolean) {
     if (canReportDiagnostics(system, compilerOptions)) {
-        ts.performance.enable(system);
+        performance.enable(system);
     }
 
     if (canTrace(system, compilerOptions)) {
@@ -1104,11 +1105,11 @@ function reportStatistics(sys: System, programOrConfig: Program | ParsedCommandL
             reportStatisticalValue({ name: "Memory used", value: memoryUsed, type: StatisticType.memory }, /*aggregate*/ true);
         }
 
-        const isPerformanceEnabled = ts.performance.isEnabled();
-        const programTime = isPerformanceEnabled ? ts.performance.getDuration("Program") : 0;
-        const bindTime = isPerformanceEnabled ? ts.performance.getDuration("Bind") : 0;
-        const checkTime = isPerformanceEnabled ? ts.performance.getDuration("Check") : 0;
-        const emitTime = isPerformanceEnabled ? ts.performance.getDuration("Emit") : 0;
+        const isPerformanceEnabled = performance.isEnabled();
+        const programTime = isPerformanceEnabled ? performance.getDuration("Program") : 0;
+        const bindTime = isPerformanceEnabled ? performance.getDuration("Bind") : 0;
+        const checkTime = isPerformanceEnabled ? performance.getDuration("Check") : 0;
+        const emitTime = isPerformanceEnabled ? performance.getDuration("Emit") : 0;
         if (compilerOptions.extendedDiagnostics) {
             if (program) {
                 const caches = program.getRelationCacheSizes();
@@ -1118,7 +1119,7 @@ function reportStatistics(sys: System, programOrConfig: Program | ParsedCommandL
                 reportCountStatistic("Strict subtype cache size", caches.strictSubtype);
             }
             if (isPerformanceEnabled) {
-                ts.performance.forEachMeasure((name, duration) => {
+                performance.forEachMeasure((name, duration) => {
                     if (!isSolutionMarkOrMeasure(name)) reportTimeStatistic(`${name} time`, duration, /*aggregate*/ true);
                 });
             }
@@ -1128,8 +1129,8 @@ function reportStatistics(sys: System, programOrConfig: Program | ParsedCommandL
             // Note: To match the behavior of previous versions of the compiler, the reported parse time includes
             // I/O read time and processing time for triple-slash references and module imports, and the reported
             // emit time includes I/O write time. We preserve this behavior so we can accurately compare times.
-            reportTimeStatistic("I/O read", ts.performance.getDuration("I/O Read"), /*aggregate*/ true);
-            reportTimeStatistic("I/O write", ts.performance.getDuration("I/O Write"), /*aggregate*/ true);
+            reportTimeStatistic("I/O read", performance.getDuration("I/O Read"), /*aggregate*/ true);
+            reportTimeStatistic("I/O write", performance.getDuration("I/O Write"), /*aggregate*/ true);
             reportTimeStatistic("Parse time", programTime, /*aggregate*/ true);
             reportTimeStatistic("Bind time", bindTime, /*aggregate*/ true);
             reportTimeStatistic("Check time", checkTime, /*aggregate*/ true);
@@ -1145,15 +1146,15 @@ function reportStatistics(sys: System, programOrConfig: Program | ParsedCommandL
         else {
             if (solutionPerformance) {
                 // Clear selected marks and measures
-                ts.performance.forEachMeasure(name => {
-                    if (!isSolutionMarkOrMeasure(name)) ts.performance.clearMeasures(name);
+                performance.forEachMeasure(name => {
+                    if (!isSolutionMarkOrMeasure(name)) performance.clearMeasures(name);
                 });
-                ts.performance.forEachMark(name => {
-                    if (!isSolutionMarkOrMeasure(name)) ts.performance.clearMarks(name);
+                performance.forEachMark(name => {
+                    if (!isSolutionMarkOrMeasure(name)) performance.clearMarks(name);
                 });
             }
             else {
-                ts.performance.disable();
+                performance.disable();
             }
         }
     }


### PR DESCRIPTION
I should report this upstream, if I can manage to minimize this.

---

**Please do not comment on this PR**. Depending on how this set of PRs evolves, this PR's contents may change entirely based on the order of commits.

This PR is a part of a stack:

  1. [Make a few changes to allow all code to be loaded as one project](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-1)
  1. [Explicitly reference ts namespace in tsserverlibrary](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-2)
  1. [Generated module conversion step - unindent](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-3)
  1. [Generated module conversion step - explicitify](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-4)
  1. [Generated module conversion step - stripNamespaces](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-5)
  1. [Generated module conversion step - inlineImports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-6)
  1. [Generated module conversion step - .git-ignore-blame-revs](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-7)
  1. [Add gitlens settings suggestion](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-8)
  1. [Make processDiagnosticMessages generate a module](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-9)
  1. [Fix up linting, make lint clean](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-10)
  1. [Undo changes needed to load codebase into ts-morph](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-11)
  1. [Add JSDoc eslint rule](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-12)
  1. [Fix all internal JSDoc comments](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-13)
  1. [Convert require calls to imports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-14)
  1. [Remove typescriptServices, protocol.d.ts, typescript_standalone.d.ts](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-15)
  1. [Get codebase building pre bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-16)
  1. [Add build via esbuild](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-17)
  1. [Add dts bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-18)
  1. [Consolidate checks that test if the current environment is Node](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-19)
  1. [Add ts to globalThis in run.js for convenience during debugging](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-20)
  1. [Rename Gulpfile to Herebyfile for improved git diff](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-21)
  1. [Change build system to hereby](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-22)
  1. [Update baselines for corrected line endings in lib files](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-23)
  1. [Use jsonc-parser instead of LKG compiler in build](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-24)
  1. [Modernize localize script, use new XML library](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-25)
  1. [Don't use needsUpdate for quick tasks](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-26)
  1. [Remove mkdirp](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-27)
  1. [Export ts namespace from tsserver for hacky-post patching](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-28)
  1. Directly import namespaces for improved esbuild output (this PR)
  1. [Ensure ts object passed to plugins contains deprecatedCompat declarations](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-30)
  1. [Move compiler-debug into Debug namespace, which allows the compiler to be tree shaken](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-31)
  1. [Remove Promise redeclaration](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-32)
  1. [Remove globalThisShim and globalThis modification for TypeScriptServicesFactory](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-33)
  1. [Disable slow CodeQL queries](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-34)
  1. [Remove outFiles from launch.json](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-35)
  1. [Remove dynamicImport and setDynamicImport](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-36)