### PR TITLE
Ensure ts object passed to plugins contains deprecatedCompat declarations

### DIFF
--- a/src/server/_namespaces/ts.ts
+++ b/src/server/_namespaces/ts.ts
@@ -3,5 +3,7 @@
 export * from "../../compiler/_namespaces/ts";
 export * from "../../jsTyping/_namespaces/ts";
 export * from "../../services/_namespaces/ts";
+// Pull this in here so that plugins loaded by the server see compat wrappers.
+export * from "../../deprecatedCompat/_namespaces/ts";
 import * as server from "./ts.server";
 export { server };

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -8,7 +8,8 @@
     "references": [
         { "path": "../compiler" },
         { "path": "../jsTyping" },
-        { "path": "../services" }
+        { "path": "../services" },
+        { "path": "../deprecatedCompat" }
     ],
     "include": ["**/*"]
 }

--- a/src/tsserver/_namespaces/ts.ts
+++ b/src/tsserver/_namespaces/ts.ts
@@ -5,6 +5,5 @@ export * from "../../services/_namespaces/ts";
 export * from "../../jsTyping/_namespaces/ts";
 export * from "../../server/_namespaces/ts";
 export * from "../../webServer/_namespaces/ts";
-export * from "../../deprecatedCompat/_namespaces/ts";
 import * as server from "./ts.server";
 export { server };

--- a/src/tsserver/tsconfig.json
+++ b/src/tsserver/tsconfig.json
@@ -11,8 +11,7 @@
         { "path": "../services" },
         { "path": "../jsTyping" },
         { "path": "../server" },
-        { "path": "../webServer" },
-        { "path": "../deprecatedCompat" }
+        { "path": "../webServer" }
     ],
     "include": ["**/*"]
 }

--- a/src/tsserverlibrary/_namespaces/ts.ts
+++ b/src/tsserverlibrary/_namespaces/ts.ts
@@ -4,6 +4,5 @@ export * from "../../compiler/_namespaces/ts";
 export * from "../../jsTyping/_namespaces/ts";
 export * from "../../services/_namespaces/ts";
 export * from "../../server/_namespaces/ts";
-export * from "../../deprecatedCompat/_namespaces/ts";
 import * as server from "./ts.server";
 export { server };

--- a/src/tsserverlibrary/tsconfig.json
+++ b/src/tsserverlibrary/tsconfig.json
@@ -6,8 +6,7 @@
         { "path": "../compiler" },
         { "path": "../jsTyping" },
         { "path": "../services" },
-        { "path": "../server" },
-        { "path": "../deprecatedCompat" }
+        { "path": "../server" }
     ],
     "include": ["**/*"]
 }


### PR DESCRIPTION
We pass the entire "ts" object into plugins. However, we need to make
sure that that object contains the debug compat helpers.

In the old codebase, the deprecated compat code would tack things onto
the actual ts object, after the server code was executed, and later that
same object would be given to plugins.

But in modules, each TS project only sees the view of the "ts" namespace
that their references implied, not the ts object as some sort of
singleton. To ensure that plugins get the debug compat code, we have to
bring that into each project's view of the ts namespace, and not add it
on later in the executable projects.

---

**Please do not comment on this PR**. Depending on how this set of PRs evolves, this PR's contents may change entirely based on the order of commits.

This PR is a part of a stack:

  1. [Make a few changes to allow all code to be loaded as one project](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-1)
  1. [Explicitly reference ts namespace in tsserverlibrary](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-2)
  1. [Generated module conversion step - unindent](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-3)
  1. [Generated module conversion step - explicitify](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-4)
  1. [Generated module conversion step - stripNamespaces](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-5)
  1. [Generated module conversion step - inlineImports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-6)
  1. [Generated module conversion step - .git-ignore-blame-revs](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-7)
  1. [Add gitlens settings suggestion](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-8)
  1. [Make processDiagnosticMessages generate a module](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-9)
  1. [Fix up linting, make lint clean](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-10)
  1. [Undo changes needed to load codebase into ts-morph](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-11)
  1. [Add JSDoc eslint rule](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-12)
  1. [Fix all internal JSDoc comments](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-13)
  1. [Convert require calls to imports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-14)
  1. [Remove typescriptServices, protocol.d.ts, typescript_standalone.d.ts](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-15)
  1. [Get codebase building pre bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-16)
  1. [Add build via esbuild](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-17)
  1. [Add dts bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-18)
  1. [Consolidate checks that test if the current environment is Node](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-19)
  1. [Add ts to globalThis in run.js for convenience during debugging](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-20)
  1. [Rename Gulpfile to Herebyfile for improved git diff](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-21)
  1. [Change build system to hereby](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-22)
  1. [Update baselines for corrected line endings in lib files](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-23)
  1. [Use jsonc-parser instead of LKG compiler in build](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-24)
  1. [Modernize localize script, use new XML library](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-25)
  1. [Don't use needsUpdate for quick tasks](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-26)
  1. [Remove mkdirp](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-27)
  1. [Export ts namespace from tsserver for hacky-post patching](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-28)
  1. [Directly import namespaces for improved esbuild output](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-29)
  1. Ensure ts object passed to plugins contains deprecatedCompat declarations (this PR)
  1. [Move compiler-debug into Debug namespace, which allows the compiler to be tree shaken](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-31)
  1. [Remove Promise redeclaration](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-32)
  1. [Remove globalThisShim and globalThis modification for TypeScriptServicesFactory](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-33)
  1. [Disable slow CodeQL queries](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-34)
  1. [Remove outFiles from launch.json](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-35)
  1. [Remove dynamicImport and setDynamicImport](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-36)