### PR TITLE
Clean up clean tasks

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -27,10 +27,6 @@ function getCopyrightHeader() {
 }
 
 
-/** @type {ReturnType<typeof task>[]} */
-const cleanTasks = [];
-
-
 // TODO(jakebailey): This is really gross. If the build is cancelled (i.e. Ctrl+C), the modification will persist.
 // Waiting on: https://github.com/microsoft/TypeScript/issues/51164
 let currentlyBuilding = 0;
@@ -101,13 +97,6 @@ export const generateLibs = task({
     },
 });
 
-const cleanLib = task({
-    name: "clean-lib",
-    hiddenFromTaskList: true,
-    run: () => del(libs.map(lib => lib.target)),
-});
-cleanTasks.push(cleanLib);
-
 
 const diagnosticInformationMapTs = "src/compiler/diagnosticInformationMap.generated.ts";
 const diagnosticMessagesJson = "src/compiler/diagnosticMessages.json";
@@ -127,7 +116,6 @@ const cleanDiagnostics = task({
     hiddenFromTaskList: true,
     run: () => del([diagnosticInformationMapTs, diagnosticMessagesGeneratedJson]),
 });
-cleanTasks.push(cleanDiagnostics);
 
 
 // Localize diagnostics
@@ -162,6 +150,7 @@ export const buildSrc = task({
 
 export const cleanSrc = task({
     name: "clean-src",
+    hiddenFromTaskList: true,
     run: () => cleanProject("src"),
 });
 
@@ -273,7 +262,6 @@ async function runDtsBundler(entrypoint, output) {
 
             await esbuild.build(options);
         },
-        clean: () => del([outfile, `${outfile}.map`]),
     };
 }
 
@@ -297,13 +285,6 @@ const buildDebugTools = task({
     run: () => cmdLineOptions.bundle ? esbuildDebugTools.build() : buildProject("src/debug"),
 });
 
-const cleanDebugTools = task({
-    name: "clean-debug-tools",
-    hiddenFromTaskList: true,
-    run: () => cmdLineOptions.bundle ? esbuildDebugTools.build() : cleanProject("src/debug")
-});
-cleanTasks.push(cleanDebugTools);
-
 
 const esbuildTsc = esbuildTask("./src/tsc/tsc.ts", "./built/local/tsc.js");
 
@@ -318,13 +299,6 @@ export const buildTsc = task({
     }
 });
 
-export const cleanTsc = task({
-    name: "clean-tsc",
-    description: "Cleans outputs for the command-line compiler",
-    hiddenFromTaskList: true,
-    run: () => cmdLineOptions.bundle ? esbuildTsc.clean() : cleanProject("src/tsc"),
-});
-cleanTasks.push(cleanTsc);
 
 const buildServicesWithTsc = task({
     name: "services-src",
@@ -345,14 +319,6 @@ export const buildServices = task({
         await writeCJSReexport("./built/local/typescript/typescript.js", "./built/local/typescript.js");
     }
 });
-
-export const cleanServices = task({
-    name: "clean-services",
-    description: "Cleans outputs for the language service",
-    hiddenFromTaskList: true,
-    run: () => cmdLineOptions.bundle ? esbuildServices.clean() : cleanProject("src/typescript"),
-});
-cleanTasks.push(cleanServices);
 
 
 export const dtsServices = task({
@@ -375,14 +341,6 @@ export const buildServer = task({
     }
 });
 
-export const cleanServer = task({
-    name: "clean-tsserver",
-    description: "Cleans outputs for the language server",
-    hiddenFromTaskList: true,
-    run: () => cmdLineOptions.bundle ? esbuildServer.clean() : cleanProject("src/tsserver"),
-});
-cleanTasks.push(cleanServer);
-
 
 export const min = task({
     name: "min",
@@ -390,12 +348,6 @@ export const min = task({
     dependencies: [buildTsc, buildServer],
 });
 
-export const cleanMin = task({
-    name: "clean-min",
-    description: "Cleans outputs for tsc and tsserver",
-    hiddenFromTaskList: true,
-    dependencies: [cleanTsc, cleanServer],
-});
 
 const buildLsslWithTsc = task({
     name: "lssl-src",
@@ -415,13 +367,6 @@ export const buildLssl = task({
     },
 });
 
-export const cleanLssl = task({
-    name: "clean-lssl",
-    description: "Clean outputs for the language service server library",
-    hiddenFromTaskList: true,
-    run: () => cmdLineOptions.bundle ? esbuildLssl.clean() : cleanProject("src/tsserverlibrary"),
-});
-cleanTasks.push(cleanLssl);
 
 export const dtsLssl = task({
     name: "dts-lssl",
@@ -457,15 +402,6 @@ export const buildTests = task({
         await buildProject("src/testRunner");
     },
 });
-
-export const cleanTests = task({
-    name: "clean-tests",
-    description: "Cleans the outputs for the test infrastructure",
-    hiddenFromTaskList: true,
-    run: () => cmdLineOptions.bundle ? esbuildTests.clean() : cleanProject("src/testRunner"),
-});
-cleanTasks.push(cleanTests);
-
 
 
 export const runEslintRulesTests = task({
@@ -510,12 +446,6 @@ const buildCancellationToken = task({
         await buildProject("src/cancellationToken");
     },
 });
-const cleanCancellationToken = task({
-    name: "clean-cancellation-token",
-    hiddenFromTaskList: true,
-    run: () => cmdLineOptions.bundle ? esbuildCancellationToken.clean() : cleanProject("src/cancellationToken"),
-});
-cleanTasks.push(cleanCancellationToken);
 
 const esbuildTypingsInstaller = esbuildTask("./src/typingsInstaller/nodeTypingsInstaller.ts", "./built/local/typingsInstaller.js");
 
@@ -528,12 +458,7 @@ const buildTypingsInstaller = task({
         await buildProject("src/typingsInstaller");
     },
 });
-const cleanTypingsInstaller = task({
-    name: "clean-typings-installer",
-    hiddenFromTaskList: true,
-    run: () => cmdLineOptions.bundle ? esbuildTypingsInstaller.clean() : cleanProject("src/typingsInstaller"),
-});
-cleanTasks.push(cleanTypingsInstaller);
+
 
 const esbuildWatchGuard = esbuildTask("./src/watchGuard/watchGuard.ts", "./built/local/watchGuard.js");
 
@@ -546,12 +471,7 @@ const buildWatchGuard = task({
         await buildProject("src/watchGuard");
     },
 });
-const cleanWatchGuard = task({
-    name: "clean-watch-guard",
-    hiddenFromTaskList: true,
-    run: () => cmdLineOptions.bundle ? esbuildWatchGuard.clean() : cleanProject("src/watchGuard"),
-});
-cleanTasks.push(cleanWatchGuard);
+
 
 export const generateTypesMap = task({
     name: "generate-types-map",
@@ -564,12 +484,6 @@ export const generateTypesMap = task({
     }
 });
 
-const cleanTypesMap = task({
-    name: "clean-types-map",
-    hiddenFromTaskList: true,
-    run: () => del("built/local/typesMap.json"),
-});
-cleanTasks.push(cleanTypesMap);
 
 // Drop a copy of diagnosticMessages.generated.json into the built/local folder. This allows
 // it to be synced to the Azure DevOps repo, so that it can get picked up by the build
@@ -585,12 +499,6 @@ const copyBuiltLocalDiagnosticMessages = task({
     }
 });
 
-const cleanBuiltLocalDiagnosticMessages = task({
-    name: "clean-built-local-diagnostic-messages",
-    hiddenFromTaskList: true,
-    run: () => del(builtLocalDiagnosticMessagesGeneratedJson),
-});
-cleanTasks.push(cleanBuiltLocalDiagnosticMessages);
 
 export const buildOtherOutputs = task({
     name: "other-outputs",
@@ -773,14 +681,16 @@ export const generateSpec = task({
     run: () => exec("cscript", ["//nologo", "scripts/word2md.mjs", path.resolve("doc/TypeScript Language Specification - ARCHIVED.docx"), path.resolve("doc/spec-ARCHIVED.md")]),
 });
 
-// TODO(jakebailey): this seems silly; most tasks in cleanTasks just remove
-// things in built, only to just remove built anyway. Instead just depend on
-// cleaning built and the diagnostics in src?
+export const cleanBuilt = task({
+    name: "clean-built",
+    hiddenFromTaskList: true,
+    run: () => del("built"),
+});
+
 export const clean = task({
     name: "clean",
     description: "Cleans build outputs",
-    dependencies: cleanTasks,
-    run: () => del("built"),
+    dependencies: [cleanBuilt, cleanDiagnostics],
 });
 
 export const configureNightly = task({


### PR DESCRIPTION
**Please do not comment on this PR**. Depending on how this set of PRs evolves, this PR's contents may change entirely based on the order of commits.

This PR is a part of a stack:

  1. [Make a few changes to allow all code to be loaded as one project](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-1)
  1. [Explicitly reference ts namespace in tsserverlibrary](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-2)
  1. [Generated module conversion step - unindent](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-3)
  1. [Generated module conversion step - explicitify](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-4)
  1. [Generated module conversion step - stripNamespaces](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-5)
  1. [Generated module conversion step - inlineImports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-6)
  1. [Generated module conversion step - .git-ignore-blame-revs](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-7)
  1. [Make processDiagnosticMessages generate a module](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-8)
  1. [Remove local ESLint rule one-namespace-per-file](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-9)
  1. [Make current state lint-clean](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-10)
  1. [Undo changes needed to load codebase into ts-morph](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-11)
  1. [Add JSDoc eslint rule](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-12)
  1. [Fix all internal JSDoc comments](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-13)
  1. [Convert require calls to imports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-14)
  1. [Remove typescriptServices project](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-15)
  1. [Remove generation of protocol.d.ts](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-16)
  1. [Remove all files in lib before LKG](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-17)
  1. [Get test suites running](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-18)
  1. [Get entrypoints working](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-19)
  1. [Add build via esbuild](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-20)
  1. [Add dts bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-21)
  1. [Consolidate checks that test if the current environment is Node](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-22)
  1. [Add ts to globalThis for convenience during debugging](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-23)
  1. [Rename Gulpfile to Herebyfile for improved git diff](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-24)
  1. [Change build system to hereby](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-25)
  1. [Update baselines for corrected line endings in lib files](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-26)
  1. [Use jsonc-parser instead of LKG compiler in build](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-27)
  1. [Modernize localize script](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-28)
  1. [Switch to faster XML parsing library for localize](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-29)
  1. [Don't use needsUpdate for quick tasks](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-30)
  1. [Remove mkdirp](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-31)
  1. [Specify rootDir and outDir in tsconfig-base rather than in each tsconfig](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-32)
  1. [Replace all files arrays with include wildcards](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-33)
  1. [Export ts namespace from tsserver for hacky-post patching](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-34)
  1. [Compute esbuild options lazily](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-35)
  1. [Build fixups](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-36)
  1. [Raise lib/target to ES2018, matching esbuild settings, and set commonjs module mode](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-37)
  1. Clean up clean tasks (this PR)
  1. [Add gitlens settings suggestion](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-39)
  1. [Overhaul tasks to do less work and more in parallel, prep for composing them](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-40)
  1. [Consolidate logic for creating entrypoint build tasks](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-41)
  1. [Build fixups](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-42)
  1. [Directly import namespaces for improved esbuild output](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-43)
  1. [Ensure ts object passed to plugins contains deprecatedCompat declarations](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-44)
  1. [Move compiler-debug into Debug namespace, which allows the compiler to be tree shaken](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-45)
  1. [Remove Promise redeclaration, our target includes Promise](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-46)
  1. [Remove globalThisShim and globalThis modification for TypeScriptServicesFactory](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-47)
  1. [Disable slow CodeQL queries](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-48)