### PR TITLE
Consolidate logic for creating entrypoint build tasks

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -14,6 +14,9 @@ import esbuild from "esbuild";
 
 const glob = util.promisify(_glob);
 
+/** @typedef {ReturnType<typeof task>} Task */
+void 0;
+
 const copyright = "CopyrightNotice.txt";
 
 /** @type {string | undefined} */
@@ -168,15 +171,16 @@ async function runDtsBundler(entrypoint, output) {
     ]);
 }
 
+
 /**
- * @typedef {{
-    external?: string[];
-    exportIsTsObject?: boolean;
-    setDynamicImport?: boolean;
-}} ESBuildTaskOptions
  * @param {string} entrypoint
  * @param {string} outfile
- * @param {ESBuildTaskOptions | undefined} [taskOptions]
+ * @param {ESBuildTaskOptions} [taskOptions]
+ *
+ * @typedef ESBuildTaskOptions
+ * @property {string[]} [external]
+ * @property {boolean} [exportIsTsObject]
+ * @property {boolean} [setDynamicImport]
  */
 async function runEsbuild(entrypoint, outfile, taskOptions = {}) {
     /** @type {esbuild.BuildOptions} */
@@ -261,88 +265,98 @@ async function runEsbuild(entrypoint, outfile, taskOptions = {}) {
     await esbuild.build(options);
 }
 
+
 /**
- * Writes a CJS module that reexports another CJS file via
- * `module.exports = require("...")`.
- *
- * @param {string} infile Relative path from the repo root to the file to be required.
- * @param {string} outfile Relative path from the repo root to the output file.
+ * @param {object} options
+ * @param {string} options.name
+ * @param {string} [options.description]
+ * @param {Task[]} [options.buildDeps]
+ * @param {string} options.project
+ * @param {string} options.srcEntrypoint
+ * @param {string} options.builtEntrypoint
+ * @param {string} options.output
+ * @param {Task[]} [options.mainDeps]
+ * @param {ESBuildTaskOptions} [options.esbuildOptions]
  */
-async function writeCJSReexport(infile, outfile) {
-    const inRelativeToOut = infile = path.relative(path.dirname(outfile), infile);
-    await fs.promises.writeFile(outfile, `module.exports = require("./${inRelativeToOut}")`);
+function entrypointBuildTask(options) {
+    const build = task({
+        name: `build-${options.name}`,
+        dependencies: options.buildDeps,
+        run: () => buildProject(options.project),
+    });
+
+    // If we ever need to bundle our own output, change this to depend on build
+    // and run esbuild on builtEntrypoint.
+    const bundle = task({
+        name: `bundle-${options.name}`,
+        dependencies: options.buildDeps,
+        run: () => runEsbuild(options.srcEntrypoint, options.output, options.esbuildOptions),
+    });
+
+    /**
+     * Writes a CJS module that reexports another CJS file. E.g. given
+     * `options.builtEntrypoint = "./built/local/tsc/tsc.js"` and
+     * `options.output = "./built/local/tsc.js"`, this will create a file
+     * named "./built/local/tsc.js" containing:
+     *
+     * ```
+     * module.exports = require("./tsc/tsc.js")
+     * ```
+     */
+    const shim = task({
+        name: `shim-${options.name}`,
+        run: async () => {
+            const outDir = path.dirname(options.output);
+            await fs.promises.mkdir(outDir, { recursive: true });
+            const moduleSpecifier = path.relative(outDir, options.builtEntrypoint);
+            await fs.promises.writeFile(options.output, `module.exports = require("./${moduleSpecifier}")`);
+        },
+    });
+
+    const main = task({
+        name: options.name,
+        description: options.description,
+        dependencies: (options.mainDeps ?? []).concat(cmdLineOptions.bundle ? [bundle] : [build, shim]),
+    });
+
+    return { build, bundle, shim, main };
 }
 
-
-const buildCompilerDebug = task({
-    name: "build-compiler-debug",
-    dependencies: [generateDiagnostics],
-    run: () => buildProject("src/debug"),
-});
-
-const bundleCompilerDebug = task({
-    name: "bundle-compiler-debug",
-    dependencies: [generateDiagnostics],
-    run: () => runEsbuild("./src/debug/compilerDebug.ts", "./built/local/compilerDebug.js"),
-});
-
-const shimCompilerDebug = task({
-    name: "shim-compiler-debug",
-    run: () => writeCJSReexport("./built/local/debug/compilerDebug.js", "./built/local/compilerDebug.js"),
-});
-
-const compilerDebug = task({
+const { main: compilerDebug } = entrypointBuildTask({
     name: "compiler-debug",
-    dependencies: cmdLineOptions.bundle ? [bundleCompilerDebug] : [buildCompilerDebug, shimCompilerDebug],
+    buildDeps: [generateDiagnostics],
+    project: "src/debug",
+    srcEntrypoint: "./src/debug/compilerDebug.ts",
+    builtEntrypoint: "./built/local/debug/compilerDebug.js",
+    output: "./built/local/compilerDebug.js",
 });
 
 
-const buildTsc = task({
-    name: "build-tsc",
-    dependencies: [generateDiagnostics],
-    run: () => buildProject("src/tsc"),
-});
-
-const bundleTsc = task({
-    name: "bundle-tsc",
-    dependencies: [generateDiagnostics],
-    run: () => runEsbuild("./src/tsc/tsc.ts", "./built/local/tsc.js"),
-});
-
-const shimTsc = task({
-    name: "shim-tsc",
-    run: () => writeCJSReexport("./built/local/tsc/tsc.js", "./built/local/tsc.js"),
-});
-
-export const tsc = task({
+const { main: tsc } = entrypointBuildTask({
     name: "tsc",
     description: "Builds the command-line compiler",
-    dependencies: [compilerDebug, generateLibs].concat(cmdLineOptions.bundle ? [bundleTsc] : [buildTsc, shimTsc]),
+    buildDeps: [generateDiagnostics],
+    project: "src/tsc",
+    srcEntrypoint: "./src/tsc/tsc.ts",
+    builtEntrypoint: "./built/local/tsc/tsc.js",
+    output: "./built/local/tsc.js",
+    mainDeps: [generateLibs, compilerDebug],
 });
+export { tsc };
 
 
-const buildServices = task({
-    name: "build-services",
-    dependencies: [generateDiagnostics],
-    run: () => buildProject("src/typescript"),
-});
-
-const bundleServices = task({
-    name: "bundle-services",
-    dependencies: [generateDiagnostics],
-    run: () => runEsbuild("./src/typescript/typescript.ts", "./built/local/typescript.js", { exportIsTsObject: true }),
-});
-
-const shimServices = task({
-    name: "shim-services",
-    run: () => writeCJSReexport("./built/local/typescript/typescript.js", "./built/local/typescript.js"),
-});
-
-export const services = task({
+const { main: services, build: buildServices } = entrypointBuildTask({
     name: "services",
-    description: "Builds the language service",
-    dependencies: [generateLibs].concat(cmdLineOptions.bundle ? [bundleServices] : [buildServices, shimServices]),
+    description: "Builds the typescript.js library",
+    buildDeps: [generateDiagnostics],
+    project: "src/typescript",
+    srcEntrypoint: "./src/typescript/typescript.ts",
+    builtEntrypoint: "./built/local/typescript/typescript.js",
+    output: "./built/local/typescript.js",
+    mainDeps: [generateLibs, compilerDebug],
+    esbuildOptions: { exportIsTsObject: true },
 });
+export { services };
 
 export const dtsServices = task({
     name: "dts-services",
@@ -351,59 +365,40 @@ export const dtsServices = task({
     run: () => runDtsBundler("./built/local/typescript/typescript.d.ts", "./built/local/typescript.d.ts"),
 });
 
-const buildServer = task({
-    name: "build-server",
-    dependencies: [generateDiagnostics],
-    run: () => buildProject("src/tsserver"),
-});
 
-const bundleServer = task({
-    name: "bundle-server",
-    dependencies: [generateDiagnostics],
-    run: () => runEsbuild("./src/tsserver/server.ts", "./built/local/tsserver.js", { exportIsTsObject: true }),
-});
-
-const shimServer = task({
-    name: "shim-server",
-    run: () => writeCJSReexport("./built/local/tsserver/server.js", "./built/local/tsserver.js"),
-});
-
-export const server = task({
+const { main: tsserver } = entrypointBuildTask({
     name: "tsserver",
     description: "Builds the language server",
-    dependencies: [generateLibs].concat(cmdLineOptions.bundle ? [bundleServer] : [buildServer, shimServer]),
+    buildDeps: [generateDiagnostics],
+    project: "src/tsserver",
+    srcEntrypoint: "./src/tsserver/server.ts",
+    builtEntrypoint: "./built/local/tsserver/server.js",
+    output: "./built/local/tsserver.js",
+    mainDeps: [generateLibs, compilerDebug],
+    esbuildOptions: { exportIsTsObject: true },
 });
+export { tsserver };
 
 
 export const min = task({
     name: "min",
     description: "Builds only tsc and tsserver",
-    dependencies: [tsc, server],
+    dependencies: [tsc, tsserver],
 });
 
 
-const buildLssl = task({
-    name: "build-lssl",
-    dependencies: [generateDiagnostics],
-    run: () => buildProject("src/tsserverlibrary"),
-});
-
-const bundleLssl = task({
-    name: "bundle-lssl",
-    dependencies: [generateDiagnostics],
-    run: () => runEsbuild("./src/tsserverlibrary/tsserverlibrary.ts", "./built/local/tsserverlibrary.js", { exportIsTsObject: true }),
-});
-
-const shimLssl = task({
-    name: "shim-lssl",
-    run: () => writeCJSReexport("./built/local/tsserverlibrary/tsserverlibrary.js", "./built/local/tsserverlibrary.js"),
-});
-
-export const lssl = task({
+const { main: lssl, build: buildLssl } = entrypointBuildTask({
     name: "lssl",
     description: "Builds language service server library",
-    dependencies: [generateLibs].concat(cmdLineOptions.bundle ? [bundleLssl] : [buildLssl, shimLssl]),
+    buildDeps: [generateDiagnostics],
+    project: "src/tsserverlibrary",
+    srcEntrypoint: "./src/tsserverlibrary/tsserverlibrary.ts",
+    builtEntrypoint: "./built/local/tsserverlibrary/tsserverlibrary.js",
+    output: "./built/local/tsserverlibrary.js",
+    mainDeps: [generateLibs, compilerDebug],
+    esbuildOptions: { exportIsTsObject: true },
 });
+export { lssl };
 
 export const dtsLssl = task({
     name: "dts-lssl",
@@ -420,16 +415,16 @@ export const dts = task({
 
 const testRunner = "./built/local/run.js";
 
-const buildTests = task({
-    name: "build-tests",
-    dependencies: [generateDiagnostics],
-    run: () => buildProject("src/testRunner"),
-});
-
-const bundleTests = task({
-    name: "bundle-tests",
-    dependencies: [generateDiagnostics],
-    run: () => runEsbuild("./src/testRunner/_namespaces/Harness.ts", testRunner, {
+const { main: tests } = entrypointBuildTask({
+    name: "tests",
+    description: "Builds the test infrastructure",
+    buildDeps: [generateDiagnostics],
+    project: "src/testRunner",
+    srcEntrypoint: "./src/testRunner/_namespaces/Harness.ts",
+    builtEntrypoint: "./built/local/testRunner/runner.js",
+    output: testRunner,
+    mainDeps: [generateLibs, compilerDebug],
+    esbuildOptions: {
         external: [
             "chai",
             "del",
@@ -437,20 +432,9 @@ const bundleTests = task({
             "mocha",
             "ms",
         ],
-    }),
+    },
 });
-
-const shimTests = task({
-    name: "shim-tests",
-    // TODO(jakebailey): can we modify the test loading to have a consistent entrypoint?
-    run: () => writeCJSReexport("./built/local/testRunner/runner.js", testRunner),
-});
-
-export const tests = task({
-    name: "tests",
-    description: "Builds the test infrastructure",
-    dependencies: [generateLibs].concat(cmdLineOptions.bundle ? [bundleTests] : [buildTests, shimTests]),
-});
+export { tests };
 
 
 export const runEslintRulesTests = task({
@@ -483,71 +467,30 @@ export const lint = task({
     }
 });
 
-
-const buildCancellationToken = task({
-    name: "build-cancellation-token",
-    run: () => buildProject("src/cancellationToken"),
-});
-
-const bundleCancellationToken = task({
-    name: "bundle-cancellation-token",
-    run: () => runEsbuild("./src/cancellationToken/cancellationToken.ts", "./built/local/cancellationToken.js"),
-});
-
-const shimCancellationToken = task({
-    name: "shim-cancellation-token",
-    run: () => writeCJSReexport("./built/local/tsserverlibrary/tsserverlibrary.js", "./built/local/tsserverlibrary.js"),
-});
-
-const cancellationToken = task({
+const { main: cancellationToken } = entrypointBuildTask({
     name: "cancellation-token",
-    dependencies: cmdLineOptions.bundle ? [bundleCancellationToken] : [buildCancellationToken, shimCancellationToken],
+    project: "src/cancellationToken",
+    srcEntrypoint: "./src/cancellationToken/cancellationToken.ts",
+    builtEntrypoint: "./built/local/cancellationToken/cancellationToken.js",
+    output: "./built/local/cancellationToken.js",
 });
 
-
-const buildTypingsInstaller = task({
-    name: "build-typings-installer",
-    dependencies: [generateDiagnostics],
-    run: () => buildProject("src/typingsInstaller"),
-});
-
-const bundleTypingsInstaller = task({
-    name: "bundle-typings-installer",
-    dependencies: [generateDiagnostics],
-    run: () => runEsbuild("./src/typingsInstaller/nodeTypingsInstaller.ts", "./built/local/typingsInstaller.js"),
-});
-
-const shimTypingsInstaller = task({
-    name: "shim-typings-installer",
-    run: () => writeCJSReexport("./built/local/typingsInstaller/nodeTypingsInstaller.js", "./built/local/typingsInstaller.js"),
-});
-
-const typingsInstaller = task({
+const { main: typingsInstaller } = entrypointBuildTask({
     name: "typings-installer",
-    dependencies: cmdLineOptions.bundle ? [bundleTypingsInstaller] : [buildTypingsInstaller, shimTypingsInstaller],
+    buildDeps: [generateDiagnostics],
+    project: "src/typingsInstaller",
+    srcEntrypoint: "./src/typingsInstaller/nodeTypingsInstaller.ts",
+    builtEntrypoint: "./built/local/typingsInstaller/nodeTypingsInstaller.js",
+    output: "./built/local/typingsInstaller.js",
 });
 
-
-const buildWatchGuard = task({
-    name: "build-watch-guard",
-    run: () => buildProject("src/watchGuard"),
-});
-
-const bundleWatchGuard = task({
-    name: "bundle-watch-guard",
-    run: () => runEsbuild("./src/watchGuard/watchGuard.ts", "./built/local/watchGuard.js"),
-});
-
-const shimWatchGuard = task({
-    name: "shim-watch-guard",
-    run: () => writeCJSReexport("./built/local/watchGuard/watchGuard.js", "./built/local/watchGuard.js"),
-});
-
-const watchGuard = task({
+const { main: watchGuard } = entrypointBuildTask({
     name: "watch-guard",
-    dependencies: cmdLineOptions.bundle ? [bundleWatchGuard] : [buildWatchGuard, shimWatchGuard],
+    project: "src/watchGuard",
+    srcEntrypoint: "./src/watchGuard/watchGuard.ts",
+    builtEntrypoint: "./built/local/watchGuard/watchGuard.js",
+    output: "./built/local/watchGuard.js",
 });
-
 
 export const generateTypesMap = task({
     name: "generate-types-map",
@@ -585,7 +528,7 @@ export const otherOutputs = task({
 export const local = task({
     name: "local",
     description: "Builds the full compiler and services",
-    dependencies: [localize, tsc, server, services, lssl, otherOutputs, dts],
+    dependencies: [localize, tsc, tsserver, services, lssl, otherOutputs, dts],
 });
 export default local;
 
@@ -693,7 +636,7 @@ export const baselineAcceptRwc = task({
 export const updateSublime = task({
     name: "update-sublime",
     description: "Updates the sublime plugin's tsserver",
-    dependencies: [server],
+    dependencies: [tsserver],
     run: async () => {
         for (const file of ["built/local/tsserver.js", "built/local/tsserver.js.map"]) {
             await fs.promises.copyFile(file, path.resolve("../TypeScript-Sublime-Plugin/tsserver/", path.basename(file)));
@@ -712,7 +655,7 @@ export const importDefinitelyTypedTests = task({
 export const produceLKG = task({
     name: "LKG",
     description: "Makes a new LKG out of the built js files",
-    dependencies: [localize, tsc, server, services, lssl, otherOutputs, dts],
+    dependencies: [localize, tsc, tsserver, services, lssl, otherOutputs, dts],
     run: async () => {
         if (!cmdLineOptions.bundle) {
             throw new Error("LKG cannot be created when --bundle=false");


### PR DESCRIPTION
**Please do not comment on this PR**. Depending on how this set of PRs evolves, this PR's contents may change entirely based on the order of commits.

This PR is a part of a stack:

  1. [Make a few changes to allow all code to be loaded as one project](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-1)
  1. [Explicitly reference ts namespace in tsserverlibrary](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-2)
  1. [Generated module conversion step - unindent](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-3)
  1. [Generated module conversion step - explicitify](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-4)
  1. [Generated module conversion step - stripNamespaces](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-5)
  1. [Generated module conversion step - inlineImports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-6)
  1. [Generated module conversion step - .git-ignore-blame-revs](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-7)
  1. [Make processDiagnosticMessages generate a module](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-8)
  1. [Remove local ESLint rule one-namespace-per-file](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-9)
  1. [Make current state lint-clean](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-10)
  1. [Undo changes needed to load codebase into ts-morph](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-11)
  1. [Add JSDoc eslint rule](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-12)
  1. [Fix all internal JSDoc comments](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-13)
  1. [Convert require calls to imports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-14)
  1. [Remove typescriptServices project](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-15)
  1. [Remove generation of protocol.d.ts](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-16)
  1. [Remove all files in lib before LKG](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-17)
  1. [Get test suites running](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-18)
  1. [Get entrypoints working](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-19)
  1. [Add build via esbuild](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-20)
  1. [Add dts bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-21)
  1. [Consolidate checks that test if the current environment is Node](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-22)
  1. [Add ts to globalThis for convenience during debugging](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-23)
  1. [Rename Gulpfile to Herebyfile for improved git diff](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-24)
  1. [Change build system to hereby](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-25)
  1. [Update baselines for corrected line endings in lib files](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-26)
  1. [Use jsonc-parser instead of LKG compiler in build](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-27)
  1. [Modernize localize script](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-28)
  1. [Switch to faster XML parsing library for localize](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-29)
  1. [Don't use needsUpdate for quick tasks](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-30)
  1. [Remove mkdirp](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-31)
  1. [Specify rootDir and outDir in tsconfig-base rather than in each tsconfig](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-32)
  1. [Replace all files arrays with include wildcards](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-33)
  1. [Export ts namespace from tsserver for hacky-post patching](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-34)
  1. [Compute esbuild options lazily](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-35)
  1. [Build fixups](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-36)
  1. [Raise lib/target to ES2018, matching esbuild settings, and set commonjs module mode](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-37)
  1. [Clean up clean tasks](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-38)
  1. [Add gitlens settings suggestion](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-39)
  1. [Overhaul tasks to do less work and more in parallel, prep for composing them](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-40)
  1. Consolidate logic for creating entrypoint build tasks (this PR)
  1. [Build fixups](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-42)
  1. [Directly import namespaces for improved esbuild output](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-43)
  1. [Ensure ts object passed to plugins contains deprecatedCompat declarations](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-44)
  1. [Move compiler-debug into Debug namespace, which allows the compiler to be tree shaken](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-45)
  1. [Remove Promise redeclaration, our target includes Promise](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-46)
  1. [Remove globalThisShim and globalThis modification for TypeScriptServicesFactory](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-47)
  1. [Disable slow CodeQL queries](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-48)