### PR TITLE
Build fixups

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -5,7 +5,7 @@ import del from "del";
 import { task } from "hereby";
 import _glob from "glob";
 import util from "util";
-import { exec, readJson, getDiffTool, getDirSize } from "./scripts/build/utils.mjs";
+import { exec, readJson, getDiffTool, getDirSize, memoize } from "./scripts/build/utils.mjs";
 import { runConsoleTests, refBaseline, localBaseline, refRwcBaseline, localRwcBaseline } from "./scripts/build/tests.mjs";
 import { buildProject as realBuildProject, cleanProject } from "./scripts/build/projects.mjs";
 import { localizationDirectories } from "./scripts/build/localization.mjs";
@@ -17,17 +17,10 @@ const glob = util.promisify(_glob);
 /** @typedef {ReturnType<typeof task>} Task */
 void 0;
 
-const copyright = "CopyrightNotice.txt";
-
-/** @type {string | undefined} */
-let copyrightHeader;
-function getCopyrightHeader() {
-    if (copyrightHeader === undefined) {
-        copyrightHeader = fs.readFileSync(copyright, "utf-8");
-        copyrightHeader.replace(/\r\n/g, "\n");
-    }
-    return copyrightHeader;
-}
+const copyright = memoize(async () => {
+    const contents = await fs.promises.readFile("CopyrightNotice.txt", "utf-8");
+    return contents.replace(/\r\n/g, "\n");
+});
 
 
 // TODO(jakebailey): This is really gross. If the build is cancelled (i.e. Ctrl+C), the modification will persist.
@@ -67,26 +60,28 @@ export const buildScripts = task({
     run: () => buildProject("scripts")
 });
 
-
-/** @type {{ libs: string[]; paths: Record<string, string | undefined>; }} */
-const libraries = readJson("./src/lib/libs.json");
-const libs = libraries.libs.map(lib => {
-    const relativeSources = ["header.d.ts", lib + ".d.ts"];
-    const relativeTarget = libraries.paths && libraries.paths[lib] || ("lib." + lib + ".d.ts");
-    const sources = relativeSources.map(s => path.posix.join("src/lib", s));
-    const target = `built/local/${relativeTarget}`;
-    return { target, relativeTarget, sources };
+const libs = memoize(() => {
+    /** @type {{ libs: string[]; paths: Record<string, string | undefined>; }} */
+    const libraries = readJson("./src/lib/libs.json");
+    const libs = libraries.libs.map(lib => {
+        const relativeSources = ["header.d.ts", lib + ".d.ts"];
+        const relativeTarget = libraries.paths && libraries.paths[lib] || ("lib." + lib + ".d.ts");
+        const sources = relativeSources.map(s => path.posix.join("src/lib", s));
+        const target = `built/local/${relativeTarget}`;
+        return { target, sources };
+    });
+    return libs;
 });
+
 
 export const generateLibs = task({
     name: "lib",
     description: "Builds the library targets",
     run: async () => {
         await fs.promises.mkdir("./built/local", { recursive: true });
-        for (const lib of libs) {
-            let output = getCopyrightHeader();
+        for (const lib of libs()) {
+            let output = await copyright();
 
-            await fs.promises.writeFile(lib.target, getCopyrightHeader());
             for (const source of lib.sources) {
                 const contents = await fs.promises.readFile(source, "utf-8");
                 // TODO(jakebailey): "\n\n" is for compatibility with our current tests; our test baselines
@@ -181,12 +176,13 @@ async function runDtsBundler(entrypoint, output) {
  * @property {string[]} [external]
  * @property {boolean} [exportIsTsObject]
  * @property {boolean} [setDynamicImport]
+ * @property {boolean} [treeShaking]
  */
 async function runEsbuild(entrypoint, outfile, taskOptions = {}) {
     /** @type {esbuild.BuildOptions} */
     const options = {
         entryPoints: [entrypoint],
-        banner: { js: getCopyrightHeader() },
+        banner: { js: await copyright() },
         bundle: true,
         outfile,
         platform: "node",
@@ -194,6 +190,7 @@ async function runEsbuild(entrypoint, outfile, taskOptions = {}) {
         format: "cjs",
         sourcemap: "linked",
         sourcesContent: false,
+        treeShaking: taskOptions.treeShaking,
         external: [
             ...(taskOptions.external ?? []),
             "source-map-support",
@@ -375,6 +372,10 @@ const { main: tsserver } = entrypointBuildTask({
     builtEntrypoint: "./built/local/tsserver/server.js",
     output: "./built/local/tsserver.js",
     mainDeps: [generateLibs, compilerDebug],
+    // Even though this seems like an exectuable, so could be the default CJS,
+    // this is used in the browser too. Do the same thing that we do for our
+    // libraries and generate an IIFE with name `ts`, as to not pollute the global
+    // scope.
     esbuildOptions: { exportIsTsObject: true },
 });
 export { tsserver };
@@ -425,6 +426,9 @@ const { main: tests } = entrypointBuildTask({
     output: testRunner,
     mainDeps: [generateLibs, compilerDebug],
     esbuildOptions: {
+        // Ensure we never drop any dead code, which might be helpful while debugging.
+        treeShaking: false,
+        // These are directly imported via import statements and should not be bundled.
         external: [
             "chai",
             "del",
@@ -595,7 +599,7 @@ export const diffRwc = task({
  * @param {string} localBaseline Path to the local copy of the baselines
  * @param {string} refBaseline Path to the reference copy of the baselines
  */
-function createBaselineAccept(localBaseline, refBaseline) {
+function baselineAcceptTask(localBaseline, refBaseline) {
     /**
      * @param {string} p
      */
@@ -622,13 +626,13 @@ function createBaselineAccept(localBaseline, refBaseline) {
 export const baselineAccept = task({
     name: "baseline-accept",
     description: "Makes the most recent test results the new baseline, overwriting the old baseline",
-    run: createBaselineAccept(localBaseline, refBaseline),
+    run: baselineAcceptTask(localBaseline, refBaseline),
 });
 
 export const baselineAcceptRwc = task({
     name: "baseline-accept-rwc",
     description: "Makes the most recent rwc test results the new baseline, overwriting the old baseline",
-    run: createBaselineAccept(localRwcBaseline, refRwcBaseline),
+    run: baselineAcceptTask(localRwcBaseline, refRwcBaseline),
 });
 
 // TODO(rbuckton): Determine if we still need this task. Depending on a relative
@@ -671,7 +675,7 @@ export const produceLKG = task({
             "built/local/typescript.d.ts",
             "built/local/typingsInstaller.js",
             "built/local/watchGuard.js",
-        ].concat(libs.map(lib => lib.target));
+        ].concat(libs().map(lib => lib.target));
         const missingFiles = expectedFiles
             .concat(localizationTargets)
             .filter(f => !fs.existsSync(f));

--- a/scripts/build/utils.mjs
+++ b/scripts/build/utils.mjs
@@ -200,3 +200,20 @@ export class Debouncer {
         }
     }
 }
+
+const unset = Symbol();
+/**
+ * @template T
+ * @param {() => T} fn
+ * @returns {() => T}
+ */
+export function memoize(fn) {
+    /** @type {T | unset} */
+    let value = unset;
+    return () => {
+        if (value === unset) {
+            value = fn();
+        }
+        return value;
+    };
+}


### PR DESCRIPTION
**Please do not comment on this PR**. Depending on how this set of PRs evolves, this PR's contents may change entirely based on the order of commits.

This PR is a part of a stack:

  1. [Make a few changes to allow all code to be loaded as one project](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-1)
  1. [Explicitly reference ts namespace in tsserverlibrary](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-2)
  1. [Generated module conversion step - unindent](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-3)
  1. [Generated module conversion step - explicitify](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-4)
  1. [Generated module conversion step - stripNamespaces](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-5)
  1. [Generated module conversion step - inlineImports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-6)
  1. [Generated module conversion step - .git-ignore-blame-revs](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-7)
  1. [Make processDiagnosticMessages generate a module](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-8)
  1. [Remove local ESLint rule one-namespace-per-file](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-9)
  1. [Make current state lint-clean](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-10)
  1. [Undo changes needed to load codebase into ts-morph](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-11)
  1. [Add JSDoc eslint rule](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-12)
  1. [Fix all internal JSDoc comments](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-13)
  1. [Convert require calls to imports](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-14)
  1. [Remove typescriptServices project](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-15)
  1. [Remove generation of protocol.d.ts](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-16)
  1. [Remove all files in lib before LKG](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-17)
  1. [Get test suites running](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-18)
  1. [Get entrypoints working](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-19)
  1. [Add build via esbuild](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-20)
  1. [Add dts bundling](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-21)
  1. [Consolidate checks that test if the current environment is Node](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-22)
  1. [Add ts to globalThis for convenience during debugging](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-23)
  1. [Rename Gulpfile to Herebyfile for improved git diff](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-24)
  1. [Change build system to hereby](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-25)
  1. [Update baselines for corrected line endings in lib files](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-26)
  1. [Use jsonc-parser instead of LKG compiler in build](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-27)
  1. [Modernize localize script](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-28)
  1. [Switch to faster XML parsing library for localize](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-29)
  1. [Don't use needsUpdate for quick tasks](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-30)
  1. [Remove mkdirp](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-31)
  1. [Specify rootDir and outDir in tsconfig-base rather than in each tsconfig](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-32)
  1. [Replace all files arrays with include wildcards](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-33)
  1. [Export ts namespace from tsserver for hacky-post patching](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-34)
  1. [Compute esbuild options lazily](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-35)
  1. [Build fixups](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-36)
  1. [Raise lib/target to ES2018, matching esbuild settings, and set commonjs module mode](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-37)
  1. [Clean up clean tasks](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-38)
  1. [Add gitlens settings suggestion](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-39)
  1. [Overhaul tasks to do less work and more in parallel, prep for composing them](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-40)
  1. [Consolidate logic for creating entrypoint build tasks](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-41)
  1. Build fixups (this PR)
  1. [Directly import namespaces for improved esbuild output](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-43)
  1. [Ensure ts object passed to plugins contains deprecatedCompat declarations](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-44)
  1. [Move compiler-debug into Debug namespace, which allows the compiler to be tree shaken](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-45)
  1. [Remove Promise redeclaration, our target includes Promise](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-46)
  1. [Remove globalThisShim and globalThis modification for TypeScriptServicesFactory](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-47)
  1. [Disable slow CodeQL queries](https://github.com/jakebailey/TypeScript/pull/transform-stack-commit-48)